### PR TITLE
Event emitter thread fixes

### DIFF
--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.java
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.java
@@ -639,8 +639,6 @@ public class BitmovinYospacePlayer extends BitmovinPlayer {
         }
     };
 
-    private static final String TAG = "d9837438274";
-
     /**
      * TrueX Event Handlers
      */


### PR DESCRIPTION
Not all `yospaceEventEmitter` calls need to be passed to a UI handler/runnable, as many of them are already on the UI thread. This PR fixes this issue, so that `yospaceEventEmitter` is called on the UI thread only if necessary. 