### PR TITLE
Fixed incorrect order of ad events with null TrueX configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ And this line to your main project `build.gradle`
 
 ```
 dependencies {
-    compile 'com.bitmovin.player.integration:yospace:0.9.17'
+    compile 'com.bitmovin.player.integration:yospace:0.9.20'
 }
 ```
 

--- a/yospace/build.gradle
+++ b/yospace/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'maven-publish'
 
 def packageName = 'com.bitmovin.player.integration'
-def libraryVersion = '0.9.19'
+def libraryVersion = '0.9.20'
 
 android {
     compileSdkVersion 27
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 27
-        versionCode 22
-        versionName "0.9.19"
+        versionCode 23
+        versionName "0.9.20"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.java
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.java
@@ -229,6 +229,7 @@ public class BitmovinYospacePlayer extends BitmovinPlayer {
     private void resetYospaceSession() {
         if (session != null) {
             sessionStatus = YospaceSesssionStatus.NOT_INITIALIZED;
+            session.removeAnalyticListener(analyticEventListener);
             session.shutdown();
             session = null;
             super.unload();
@@ -523,10 +524,10 @@ public class BitmovinYospacePlayer extends BitmovinPlayer {
         @Override
         public void onSourceUnloaded(SourceUnloadedEvent sourceUnloadedEvent) {
             if (sessionStatus != YospaceSesssionStatus.NOT_INITIALIZED) {
+                Log.d(Constants.TAG, "Sending Stopped Event" + getYospaceTime());
+                stateSource.notify(new PlayerState(PlaybackState.STOPPED, getYospaceTime(), false));
                 resetYospaceSession();
             }
-            Log.d(Constants.TAG, "Sending Stopped Event" + getYospaceTime());
-            stateSource.notify(new PlayerState(PlaybackState.STOPPED, getYospaceTime(), false));
         }
     };
 

--- a/yospacesample/build.gradle
+++ b/yospacesample/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.bitmovin.player.integration.yospacesample"
         minSdkVersion 19
         targetSdkVersion 27
-        versionCode 22
-        versionName "0.9.19"
+        versionCode 23
+        versionName "0.9.20"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.java
+++ b/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.java
@@ -145,7 +145,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     }
 
     private void loadTrueX() {
-        SourceItem sourceItem = new SourceItem(new HLSSource("https://turnercmaf.cdn.turner.com/csm/qa/cmaf_advanced_fmp4_from_inter/prog_seg/bones_RADS1008071800025944_v12/clear/3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c/master_cl_ifp.m3u8?context=525955018"));
+        SourceItem sourceItem = new SourceItem(new HLSSource("https://turnercmaf.warnermediacdn.com/csm/qa/cmaf_advanced_fmp4_from_inter/prog_seg/bones_RADS1008071800025944_v12/clear/3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c/master_cl_ifp.m3u8?context=525955018"));
         SourceConfiguration sourceConfig = new SourceConfiguration();
         sourceConfig.addSourceItem(sourceItem);
 


### PR DESCRIPTION
This PR ensures `AdBreakStartedEvent` and `AdStartedEvent` are fired even when the TrueX configuration is null.