### PR TITLE
Update 0.9.21

### DIFF
--- a/yospace/build.gradle
+++ b/yospace/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 27
-        versionCode 23
-        versionName "0.9.20"
+        versionCode 24
+        versionName "0.9.21"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
@@ -37,7 +37,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation 'com.bitmovin.player:playercore:2.29+'
+    implementation 'com.bitmovin.player:playercore:2.32+'
     implementation('com.truex:TruexAdRenderer:1.0.8') {
         exclude group: 'com.android.support'
         exclude module: 'appcompat-v7'

--- a/yospacesample/build.gradle
+++ b/yospacesample/build.gradle
@@ -6,9 +6,10 @@ android {
         applicationId "com.bitmovin.player.integration.yospacesample"
         minSdkVersion 19
         targetSdkVersion 27
-        versionCode 23
-        versionName "0.9.20"
+        versionCode 24
+        versionName "0.9.21"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
     buildTypes {
         release {
@@ -31,7 +32,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation 'com.bitmovin.player:playercore:2.29+'
+    implementation 'com.bitmovin.player:playercore:2.32+'
     implementation ('com.truex:TruexAdRenderer:1.0.8') {
         exclude group: 'com.android.support'
         exclude module: 'appcompat-v7'


### PR DESCRIPTION
* Update bitmovin player to `2.32+`
* Enabled multi dex (required due to increased method count in bitmovin player dependency)
* Bump version