### PR TITLE
Set default live session to DIRECT

### DIFF
--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/config/YospaceConfigurationBuilder.java
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/config/YospaceConfigurationBuilder.java
@@ -7,7 +7,7 @@ public class YospaceConfigurationBuilder {
     private int readTimeout;
     private int connectTimeout;
     private int requestTimeout;
-    private YospaceLiveInitialisationType liveInitialisationType = YospaceLiveInitialisationType.PROXY;
+    private YospaceLiveInitialisationType liveInitialisationType = YospaceLiveInitialisationType.DIRECT;
     private boolean debug = false;
 
     public YospaceConfigurationBuilder() {


### PR DESCRIPTION
Set default live session to `DIRECT` (instead of `PROXY`)