### PR TITLE
Make live session initialisation configurable

### DIFF
--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/YospaceLiveInitialisationType.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/YospaceLiveInitialisationType.kt
@@ -1,0 +1,6 @@
+package com.bitmovin.player.integration.yospace
+
+enum class YospaceLiveInitialisationType {
+    DIRECT,
+    PROXY
+}

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/config/YospaceConfiguration.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/config/YospaceConfiguration.kt
@@ -1,9 +1,12 @@
 package com.bitmovin.player.integration.yospace.config
 
+import com.bitmovin.player.integration.yospace.YospaceLiveInitialisationType
+
 data class YospaceConfiguration(
         val userAgent: String? = null,
         val readTimeout: Int = 25_000,
         val connectTimeout: Int = 25_000,
         val requestTimeout: Int = 25_000,
+        val liveInitialisationType: YospaceLiveInitialisationType = YospaceLiveInitialisationType.DIRECT,
         val isDebug: Boolean = false
 )

--- a/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
+++ b/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
@@ -16,6 +16,7 @@ import com.bitmovin.player.config.media.SourceItem
 import com.bitmovin.player.integration.yospace.BitmovinYospacePlayer
 import com.bitmovin.player.integration.yospace.YospaceAdStartedEvent
 import com.bitmovin.player.integration.yospace.YospaceAssetType
+import com.bitmovin.player.integration.yospace.YospaceLiveInitialisationType
 import com.bitmovin.player.integration.yospace.config.TruexConfiguration
 import com.bitmovin.player.integration.yospace.config.YospaceConfiguration
 import com.bitmovin.player.integration.yospace.config.YospaceSourceConfiguration
@@ -43,7 +44,12 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
         defaultButton.setOnClickListener(this)
 
         val playerConfiguration = PlayerConfiguration()
-        val yospaceConfiguration = YospaceConfiguration(readTimeout = 25_000, connectTimeout = 25_000, requestTimeout = 25_000)
+        val yospaceConfiguration = YospaceConfiguration(
+            readTimeout = 25_000,
+            connectTimeout = 25_000,
+            requestTimeout = 25_000,
+            liveInitialisationType = YospaceLiveInitialisationType.PROXY
+        )
         truexConfiguration = TruexConfiguration(bitmovinPlayerView, "turner_bm_ys_tester_001", "qa-get.truex.com/07d5fe7cc7f9b5ab86112433cf0a83b6fb41b092/vast/config?asnw=&cpx_url=&dimension_2=0&flag=%2Bamcb%2Bemcr%2Bslcb%2Bvicb%2Baeti-exvt&fw_key_values=&metr=0&network_user_id=turner_bm_ys_tester_001&prof=g_as3_truex&ptgt=a&pvrn=&resp=vmap1&slid=fw_truex&ssnw=&stream_position=midroll&vdur=&vprn=")
 
         bitmovinYospacePlayer = BitmovinYospacePlayer(applicationContext, playerConfiguration, yospaceConfiguration)


### PR DESCRIPTION
- Kotlin update to make live session initialisation configurable (PROXY or DIRECT)
- Fixes [tub-lib #373](https://github.com/TurnerOpenPlatform/tub-lib/issues/373)