### PR TITLE
Fire AdSkippedEvent when paused during live ad

### DIFF
--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.java
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.java
@@ -240,6 +240,8 @@ public class BitmovinYospacePlayer extends BitmovinPlayer {
         }
         isYospaceAd = false;
         adFree = false;
+        isLiveAdPaused = false;
+        pausedTime = 0;
         liveAd = null;
         liveAdBreak = null;
         adTimeline = null;


### PR DESCRIPTION
Fix for [tub-lib #134](https://github.com/TurnerOpenPlatform/tub-lib/issues/134) 
* Fire`AdSkippedEvent` if paused during ad and resumed during main content