### PR TITLE
Fix suppressed playback controls

### DIFF
--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -267,7 +267,7 @@ open class BitmovinYospacePlayer(
     ///////////////////////////////////////////////////////////////
 
     override fun pause() {
-        if (yospaceSession?.canPause() ?: yospaceSession == null) {
+        if (yospaceSession?.canPause() == true || yospaceSession == null) {
             super.pause()
         }
     }
@@ -308,7 +308,7 @@ open class BitmovinYospacePlayer(
     }
 
     override fun mute() {
-        if (yospaceSession?.canMute() ?: yospaceSession == null) {
+        if (yospaceSession?.canMute() == true || yospaceSession == null) {
             super.mute()
         }
     }


### PR DESCRIPTION
Fix for [tub-lib 618](https://github.com/TurnerOpenPlatform/tub-lib/issues/618)

`pause()` and `mute()` were not being called on the BM player for YoSpace content