### PR TITLE
Current time fixes

### DIFF
--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -138,7 +138,8 @@ open class BitmovinYospacePlayer(
             }
         })
 
-        super.addEventListener(OnTimeChangedListener { timeChangedEvent ->
+        super.addEventListener(OnTimeChangedListener {
+            val timeChangedEvent = TimeChangedEvent(currentTime)
             if (yospaceSession as? SessionLive != null) {
                 // Live session
                 val adSkippedEvent = AdSkippedEvent(activeAd)
@@ -157,8 +158,7 @@ open class BitmovinYospacePlayer(
             } else {
                 // Non-live session
                 yospaceStateSource.notify(PlayerState(PlaybackState.PLAYHEAD_UPDATE, yospaceTime, false))
-                val event = TimeChangedEvent(currentTime)
-                handler.post { yospaceEventEmitter.emit(event) }
+                handler.post { yospaceEventEmitter.emit(timeChangedEvent) }
             }
         })
 


### PR DESCRIPTION
Fixes [MECBM-365](https://jiraprod.turner.com/browse/MECBM-365)

`onTimeChangedListener` was emitting an absolute time value from the BM player for live content. This PR uses the time value calculated in `getCurrentTime()` to ensure ad time is respected for live content.