### PR TITLE
Expose VAST extension node

### DIFF
--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/Ad.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/Ad.kt
@@ -1,6 +1,7 @@
 package com.bitmovin.player.integration.yospace
 
 import com.bitmovin.player.model.advertising.AdData
+import com.yospace.android.xml.XmlNode
 
 data class Ad(
     override var id: String?,
@@ -11,6 +12,7 @@ data class Ad(
     val sequence: Int,
     val hasInteractiveUnit: Boolean,
     val isTruex: Boolean,
+    val extensions: List<XmlNode>,
     override val isLinear: Boolean,
     override var clickThroughUrl: String? = null,
     override var data: AdData? = null,

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/util/AdvertExt.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/util/AdvertExt.kt
@@ -22,6 +22,7 @@ fun List<YsAd>.toAds(adBreakAbsoluteStart: Double, adBreakRelativeStart: Double)
             it.sequence,
             it.hasLinearInteractiveUnit(),
             it.isTruex(),
+            it.extensions,
             !it.isTruex(),
             it.adClickThroughUrl()
         )
@@ -39,6 +40,7 @@ fun YsAd.toAd(absoluteStart: Double = startMillis / 1000.0, relativeStart: Doubl
     sequence = sequence,
     hasInteractiveUnit = hasLinearInteractiveUnit(),
     isTruex = hasLinearInteractiveUnit(),
+    extensions = extensions,
     isLinear = !hasLinearInteractiveUnit(),
     clickThroughUrl = adClickThroughUrl()
 )


### PR DESCRIPTION
* Expose VAST extension node in Ad (required for OM integration)
* Fix ad param name `isHasInteractiveUnit` -> `hasInteractiveUnit`