### PR TITLE
rename functions

### DIFF
--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -82,7 +82,7 @@ open class BitmovinYospacePlayer(
     init {
         BitLog.isEnabled = yospaceConfig.isDebug
         BitLog.d("Version ${BuildConfig.BUILD_TYPE}")
-        addEventListeners()
+        onYospaceEvents()
     }
 
     ///////////////////////////////////////////////////////////////
@@ -314,7 +314,7 @@ open class BitmovinYospacePlayer(
     // Player Event Listeners
     ///////////////////////////////////////////////////////////////
 
-    private fun addEventListeners() {
+    private fun onYospaceEvents() {
         yospaceMetadataSource.addListener {
             BitLog.d("Sending Timed Metadata: $yospaceTime")
             yospaceSession?.onTimedMetadata(it.payload)


### PR DESCRIPTION
Based on the suggestions from Lukas, function `addEventListeners` is renamed as `onYospaceEvents`.

It register all interested events for Yospace session using quick fire-and-forget subscription from v3 APIs.