### PR TITLE
Add CI and tag-driven release automation via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,16 @@ jobs:
       YOSPACE_TOKEN: ${{ secrets.YOSPACE_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Verify CHANGELOG format
         run: ./gradlew getChangelog -q --console=plain --unreleased

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - 'feature/**'
+      - 'fix/**'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  lint_and_build:
+    runs-on: ubuntu-latest
+    env:
+      YOSPACE_USER: ${{ secrets.YOSPACE_USER }}
+      YOSPACE_TOKEN: ${{ secrets.YOSPACE_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Verify CHANGELOG format
+        run: ./gradlew getChangelog -q --console=plain --unreleased
+
+      - name: Android Lint
+        run: ./gradlew lint
+
+      - name: Build
+        run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,17 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
-      - 'feature/**'
-      - 'fix/**'
   pull_request:
     branches:
       - main
   workflow_dispatch:
+
+# Cancel superseded runs on the same ref. The push and pull_request events use
+# different refs (refs/heads/* vs refs/pull/*/merge), so the PR run is not cancelled
+# by its branch's push run; only stale runs of the same event+ref are.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint_and_build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decides whether the build should run. A push to a non-default branch is skipped when
+  # an open PR already exists for it, since the pull_request event covers that branch.
+  # PRs, workflow_dispatch, and pushes to main always run.
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Decide whether to run
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "push" ] || [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          OPEN_PRS=$(gh pr list --repo "${{ github.repository }}" \
+            --head "${{ github.ref_name }}" --state open --json number --jq 'length')
+          if [ "$OPEN_PRS" -gt 0 ]; then
+            echo "Open PR exists for ${{ github.ref_name }}; the pull_request run covers it. Skipping push run."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   lint_and_build:
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     env:
       YOSPACE_USER: ${{ secrets.YOSPACE_USER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Deploy key with write access, allowed to bypass main's branch protection.
           ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
@@ -25,13 +25,13 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       # Validate before mutating anything: never tag or publish a broken build.
       - name: Build
@@ -64,7 +64,7 @@ jobs:
         run: ./gradlew artifactoryPublish
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.next }}
           body_path: build/release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,21 @@ jobs:
       - name: Publish to Artifactory
         run: ./gradlew artifactoryPublish
 
+      # Promote the release from the internal staging repo to the public, anonymously
+      # readable repo. Mirrors the copy step used by player-android and the analytics SDK.
+      - name: Promote artifact to public-releases
+        run: |
+          VERSION="${{ steps.version.outputs.next }}"
+          ARTIFACT_PATH="com/bitmovin/player/integration/yospace/${VERSION}"
+          HTTP_STATUS=$(curl -sS -o /tmp/copy-response.json -w '%{http_code}' \
+            -X POST -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" \
+            "https://bitmovin.jfrog.io/bitmovin/api/copy/libs-release-local/${ARTIFACT_PATH}?to=/public-releases/${ARTIFACT_PATH}")
+          cat /tmp/copy-response.json
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "::error::JFrog copy to public-releases failed with HTTP ${HTTP_STATUS}"
+            exit 1
+          fi
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: Release new version
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      YOSPACE_USER: ${{ secrets.YOSPACE_USER }}
+      YOSPACE_TOKEN: ${{ secrets.YOSPACE_TOKEN }}
+      ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+      ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Deploy key with write access, allowed to bypass main's branch protection.
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # Validate before mutating anything: never tag or publish a broken build.
+      - name: Build
+        run: ./gradlew build
+
+      - name: Determine next version from CHANGELOG
+        id: version
+        run: echo "next=$(./gradlew decideReleaseVersion -q --console=plain)" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version
+        run: ./gradlew bumpVersion -PnewVersion=${{ steps.version.outputs.next }}
+
+      - name: Promote CHANGELOG unreleased section
+        run: ./gradlew patchChangelog
+
+      - name: Extract release notes
+        run: ./gradlew getChangelog -q --console=plain --no-header --no-summary --no-empty-sections --project-version=${{ steps.version.outputs.next }} --output-file=build/release-notes.md
+
+      - name: Commit, tag and push
+        run: |
+          git config user.name 'Automated Release'
+          git config user.email 'release-automation@bitmovin.com'
+          git add gradle.properties CHANGELOG.md
+          git commit -m "Release ${{ steps.version.outputs.next }}"
+          git tag -a "${{ steps.version.outputs.next }}" -m "${{ steps.version.outputs.next }}"
+          git push origin main
+          git push origin "${{ steps.version.outputs.next }}"
+
+      - name: Publish to Artifactory
+        run: ./gradlew artifactoryPublish
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.next }}
+          body_path: build/release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # action-gh-release creates the GitHub Release via GITHUB_TOKEN, which needs write access.
+    permissions:
+      contents: write
     env:
       YOSPACE_USER: ${{ secrets.YOSPACE_USER }}
       YOSPACE_TOKEN: ${{ secrets.YOSPACE_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.1.0 - 2026-06-03
+## [Unreleased]
+
+## [2.1.0] - 2026-06-03
 
 ### Changed
 - Upgraded Bitmovin Player SDK to `3.154.0`
@@ -14,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Yospace ad rules are now enforced on the `Player.ads.*` API
 
-## 2.0.0
+## [2.0.0]
 
 ### Added
 - Added support for Bitmovin Player SDK v3
@@ -27,42 +29,42 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 - Support for Bitmovin Player SDK v2
 
-## 1.20.0
+## [1.20.0]
 
 ### Added
 - Added support for Yospace SDK v3
 
-## Changed
+### Changed
 - Migrated to new Listener APIs
 - Removed obsolete listeners
 - Upgraded to Java 11 and Gradle 7.2
 
-## 1.18.4
+## [1.18.4]
 
 ### Added
 - Ability to filter for specific metadata types to be fired to Yospace.
 
-## 1.18.3
+## [1.18.3]
 
 ### Changed
 - Copying thumbnailTracks from original SourceConfig to new SourceItem
 
-## 1.18.2
+## [1.18.2]
 
 ### Changed
 - Bitmovin Maven link to new Bintray URL
 
-## 1.18.1
+## [1.18.1]
 
 ### Changed
 - Bitmovin player to `2.62.1+jason`
 
-## 1.18.0
+## [1.18.0]
 
 ### Changed
 - Bitmovin player to `2.62.0+jason`
 
-## 1.17.0
+## [1.17.0]
 
 ### Added
 - `creativeId`, `title`, `avertiser`, `system`, `lineage` and `isFiller` properties to `Ad`
@@ -79,7 +81,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Player stuck in TrueX filler asset
 
-## 1.16.0
+## [1.16.0]
 
 ### Added
 - `nextAdBreak()` to `AdTimeline`
@@ -88,18 +90,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Bitmovin player to `2.58.0+jason`
 
-## 1.15.3
+## [1.15.3]
 
 ### Changed
 - `fireCompanionEvent()` in `BitmovinYospacePlayer` to `onCompanionRendered()`
 
-## 1.15.1
+## [1.15.1]
 
 ### Added
 - `fireCompanionEvent()` to `BitmovinYospacePlayer`, which sends companion tracking events
 - `id` property to `CompanionAd`
 
-## 1.15.0
+## [1.15.0]
 
 ### Added
 - Creative companion ad list `AdStartedEvent`
@@ -107,43 +109,43 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 - Duplicate `truexAd` in from `AdStartedEvent`
 
-## 1.14.0
+## [1.14.0]
 - Bitmovin player to `2.55.0+jason`
 
-## 1.13.0
+## [1.13.0]
 - Bitmovin player to `2.53.0+jason`
 
-## 1.12.0
+## [1.12.0]
 
 ### Changed
 - Bitmovin player to `2.52.0+jason`
 
-## 1.11.0
+## [1.11.0]
 
 ### Changed
 - Bitmovin player to `2.51.0+jason`
 
-## 1.10.0
+## [1.10.0]
 
 ### Changed
 - Bitmovin player to `2.50.0+jason`
 
-## 1.9.0
+## [1.9.0]
 
 ### Changed
 - Bitmovin player to `2.49.0+jason`
 
-## 1.8.0
+## [1.8.0]
 
 ### Changed
 - Bitmovin player to `2.48.0+jason`
 
-## 1.7.0
+## [1.7.0]
 
 ### Changed
 - Bitmovin player to `2.47.0+jason`
 
-## 1.6.0
+## [1.6.0]
 
 ### Added
 - Emit `AdQuartileEvent`
@@ -151,17 +153,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Player pausing indefinitely when `TruexConfiguration` is null and a TrueX ad is found
 
-## 1.5.0
+## [1.5.0]
 
 ### Changed
 - Bitmovin player to `2.46.0+jason`
 
-## 1.4.0
+## [1.4.0]
 
 ### Added
 - Ad VAST extensions property to `Ad`
 
-## 1.3.0
+## [1.3.0]
 
 ### Added
 - `position` property (pre/mid/post roll or unknown) to `AdBreak`
@@ -169,28 +171,28 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Bitmovin player `2.45.0+jason`
 
-## 1.2.2
+## [1.2.2]
 
 ### Changed
 - Bitmovin player to `2.44.0`
 
-## 1.2.1
+## [1.2.1]
 
 ### Fixed
 - Player getting stuck after attempting to seek over midroll TrueX ad break
 
-## 1.2.0
+## [1.2.0]
 
 ### Changed
 - Bitmovin player to `2.43.0`
 
-## 1.1.5
+## [1.1.5]
 
 ### Fixed
 - Ad time not respected for LIVE ads
 - Inconsistency between ad and ad break absolute time values
 
-## 1.1.4
+## [1.1.4]
 
 ### Changed
 - TrueX prerolls that meet ad free conditions now yield an ad free experience for entire session
@@ -199,7 +201,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Pause and mute suppressed for non-Yospace content
 
-## 1.1.3
+## [1.1.3]
 
 ### Changed
 - Bitmovin player to `2.41.2`
@@ -207,7 +209,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Incorrect `Ad` id for timeline ads
 
-## 1.1.2
+## [1.1.2]
 
 ### Fixed
 - `BitmovinYospacePlayerPolicy` not being respected
+
+[Unreleased]: https://github.com/bitmovin/bitmovin-player-android-integrations-yospace/compare/2.1.0...HEAD
+[2.1.0]: https://github.com/bitmovin/bitmovin-player-android-integrations-yospace/compare/2.0.0...2.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,12 +12,29 @@ Pull requests are welcome and pair well with bug reports and feature requests. H
 
 - Fork the repository to your own account if you haven't already.
 - Stay consistent to the file formats of this project.
-- Develop in a fix or feature branch (`fix/describe-your-fix`, `feature/describe-your-feature`), not in `main` or `develop`.
+- Develop in a fix or feature branch (`fix/describe-your-fix`, `feature/describe-your-feature`), not in `main`.
 - Make your changes in your fork.
 - Validate your changes according to the [Yospace Validation Procedure](https://developer.yospace.com/sdk-documentation/android/userguide/latest/en/validate-your-app.html).
 - Add an entry to the [CHANGELOG.md](CHANGELOG.md) file in the `[Unreleased]` section to describe the changes to the project.
 - Submit a pull request to the main repository.
 
 The versioning scheme we use is [SemVer](http://semver.org/).
+
+## Releasing
+
+Releases are automated and tag-driven; `main` is the only long-lived branch. Do **not** bump
+the version or edit release headings in `CHANGELOG.md` manually — just add your changes under
+the `## [Unreleased]` section in the appropriate group (`Added`, `Changed`, `Fixed`, etc.).
+
+To cut a release, a maintainer triggers the **Release new version** GitHub Action
+(`workflow_dispatch`) on `main`. It will:
+
+- determine the next version from the `## [Unreleased]` entries — `Added`/`Changed`/`Removed`
+  yield a minor bump, `Fixed`/`Security`/`Deprecated` a patch bump;
+- bump `libraryVersion` and `libraryCode` in `gradle.properties`;
+- promote the `## [Unreleased]` section to a dated version heading via the
+  [`org.jetbrains.changelog`](https://github.com/JetBrains/gradle-changelog-plugin) plugin;
+- commit, tag (`X.Y.Z`), and push `main`;
+- publish the AAR to Artifactory and create a GitHub release.
 
 All additions, modifications and fixes that are submitted will be reviewed. The project owners reserve the right to reject any pull request that does not meet our standards. We may not be able to respond to all pull requests immediately and provide no timeframes to do so.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This project is not part of a regular maintenance or update schedule. For any up
 
 As an open-source project, we are pleased to accept any and all changes, updates and fixes from the community wishing to use this project. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for more details on how to contribute.
 
+## Releasing
+
+Releasing a new version is automated and tag-driven. A maintainer triggers the **Release new version** GitHub Action (`workflow_dispatch`) on the `main` branch. The workflow determines the next version from the `## [Unreleased]` entries in [CHANGELOG.md](CHANGELOG.md) (minor for `Added`/`Changed`/`Removed`, patch for `Fixed`/`Security`/`Deprecated`), bumps the version, updates the changelog, tags the release, publishes the AAR to Artifactory, and creates a GitHub release. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+
 ## Reporting player bugs
 
 If you come across a bug related to the player, please raise this through your support ticketing system.

--- a/bitmovinpropertiesloader.gradle
+++ b/bitmovinpropertiesloader.gradle
@@ -5,3 +5,12 @@ if (propertiesFile.exists()) {
         stream -> bitmovinProperties.load(stream)
     }
 }
+
+// Environment-variable fallbacks for CI publishing. The file (if present) takes precedence,
+// so local development is unaffected. Mirrors the YOSPACE_USER / YOSPACE_TOKEN pattern in build.gradle.
+if (!bitmovinProperties.getProperty('artifactory_user') && System.getenv('ARTIFACTORY_USER')) {
+    bitmovinProperties.setProperty('artifactory_user', System.getenv('ARTIFACTORY_USER'))
+}
+if (!bitmovinProperties.getProperty('artifactory_password') && System.getenv('ARTIFACTORY_PASSWORD')) {
+    bitmovinProperties.setProperty('artifactory_password', System.getenv('ARTIFACTORY_PASSWORD'))
+}

--- a/build.gradle
+++ b/build.gradle
@@ -13,11 +13,23 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.10.1'
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:5.2.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.changelog:org.jetbrains.changelog.gradle.plugin:2.5.0"
     }
 }
 
 // Load dependencies
 apply from: 'dependencies.gradle'
+
+// Changelog management (Keep a Changelog format). Replaces the web repo's npm `kacl`.
+apply plugin: 'org.jetbrains.changelog'
+
+changelog {
+    version = providers.gradleProperty('libraryVersion').get()
+    repositoryUrl = 'https://github.com/bitmovin/bitmovin-player-android-integrations-yospace'
+    // Tags in this repo are unprefixed (e.g. 2.1.0), so drop the default "v" prefix
+    // used when building compare URLs in the link-reference footer.
+    versionPrefix = ''
+}
 
 allprojects {
     repositories {
@@ -43,4 +55,72 @@ allprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
+}
+
+// --- Release automation tasks (used by .github/workflows/release.yml) ---
+
+// Computes the next semantic version from the unreleased CHANGELOG section and prints it
+// to stdout (run with `-q --console=plain` to capture just the version):
+//   Added/Changed/Removed present -> minor bump; only Fixed/Security/Deprecated -> patch bump.
+tasks.register('decideReleaseVersion') {
+    doLast {
+        def sections = changelog.getUnreleased().sections.keySet()
+        if (sections.isEmpty()) {
+            throw new GradleException('No entries in the [Unreleased] section of CHANGELOG.md - nothing to release')
+        }
+        def minorTriggers = ['Added', 'Changed', 'Removed']
+        def patchTriggers = ['Fixed', 'Security', 'Deprecated']
+        def bump
+        if (sections.any { minorTriggers.contains(it) }) {
+            bump = 'minor'
+        } else if (sections.any { patchTriggers.contains(it) }) {
+            bump = 'patch'
+        } else {
+            throw new GradleException("No releasable entries in [Unreleased] (found sections: ${sections})")
+        }
+
+        def current = providers.gradleProperty('libraryVersion').get()
+        def parts = current.tokenize('.').collect { it.toInteger() }
+        if (parts.size() != 3) {
+            throw new GradleException("libraryVersion '${current}' is not a valid X.Y.Z version")
+        }
+        def (major, minor, patch) = parts
+        if (bump == 'minor') {
+            minor += 1
+            patch = 0
+        } else {
+            patch += 1
+        }
+        logger.quiet("${major}.${minor}.${patch}")
+    }
+}
+
+// Writes a new libraryVersion (from -PnewVersion) and increments libraryCode in gradle.properties.
+tasks.register('bumpVersion') {
+    doLast {
+        if (!project.hasProperty('newVersion')) {
+            throw new GradleException('Provide the target version: -PnewVersion=X.Y.Z')
+        }
+        def newVersion = project.property('newVersion')
+        def propsFile = rootProject.file('gradle.properties')
+        def lines = propsFile.readLines()
+        def sawVersion = false, sawCode = false
+        def updated = lines.collect { line ->
+            if (line.startsWith('libraryVersion=')) {
+                sawVersion = true
+                return "libraryVersion=${newVersion}"
+            }
+            if (line.startsWith('libraryCode=')) {
+                sawCode = true
+                def code = line.substring('libraryCode='.length()).trim().toInteger()
+                return "libraryCode=${code + 1}"
+            }
+            return line
+        }
+        if (!sawVersion || !sawCode) {
+            throw new GradleException('Could not find libraryVersion/libraryCode in gradle.properties')
+        }
+        propsFile.text = updated.join(System.lineSeparator()) + System.lineSeparator()
+        logger.lifecycle("Bumped libraryVersion -> ${newVersion}, libraryCode incremented by 1")
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,10 @@
 android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
+
+# Library coordinates. Bumped automatically by the release workflow (bumpVersion task).
+libraryVersion=2.1.0
+libraryCode=61
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/yospace/build.gradle
+++ b/yospace/build.gradle
@@ -5,8 +5,8 @@ apply plugin: 'maven-publish'
 apply from: "../bitmovinpropertiesloader.gradle"
 
 def packageName = 'com.bitmovin.player.integration'
-def libraryVersion = '2.1.0'
-def libraryCode = 61
+def libraryVersion = providers.gradleProperty('libraryVersion').get()
+def libraryCode = providers.gradleProperty('libraryCode').get().toInteger()
 
 android {
     compileSdkVersion 35


### PR DESCRIPTION
## Summary

Ports the web integration's automated release model to this repo, **without adding a Node.js dependency**. Adds CI + Release GitHub Actions workflows and moves the project to a main-only, tag-driven release flow.

## What's included

**Workflows** (`.github/workflows/`)
- `ci.yml` — verify changelog + Android lint + build, on push to `main`/`feature/**`/`fix/**`, PRs to `main`, and manual dispatch.
- `release.yml` — `workflow_dispatch` on `main`: build (validate) → auto-derive next version from CHANGELOG → bump → promote changelog → tag/push `main` → `artifactoryPublish` → GitHub release. Build runs **before** any tag/publish so a broken build is never released.

**Tooling (no Node.js)**
- `org.jetbrains.changelog` Gradle plugin (v2.5.0) replaces the web repo's `kacl`/`changelog-parser`/`semver` npm tools.
- Custom Gradle tasks `decideReleaseVersion` (minor for Added/Changed/Removed, patch for Fixed/Security/Deprecated) and `bumpVersion`.

**Supporting changes**
- `libraryVersion`/`libraryCode` moved to `gradle.properties` as the canonical source.
- `CHANGELOG.md` normalized to Keep-a-Changelog (bracketed headings, fixed the `1.20.0` heading typo, `[Unreleased]` section, link footer).
- `ARTIFACTORY_USER`/`ARTIFACTORY_PASSWORD` env fallbacks in `bitmovinpropertiesloader.gradle` for CI (file still takes precedence locally).
- README + CONTRIBUTING document the main-only, tag-driven release flow.

## Verified locally
- `decideReleaseVersion`: minor `2.1.0→2.2.0`, patch `2.1.0→2.1.1`, and safe-fail on empty `[Unreleased]`.
- `bumpVersion` rewrites `gradle.properties` (version + `libraryCode`+1).
- `patchChangelog` promotes the section and regenerates the footer with unprefixed tags.
- `./gradlew build` green; `actionlint` passes both workflows.

## Required before first release (admin actions)
1. Create repo secrets: `YOSPACE_USER`, `YOSPACE_TOKEN`, `ARTIFACTORY_USER`, `ARTIFACTORY_PASSWORD`, and `RELEASE_DEPLOY_KEY` (SSH deploy key with write + branch-protection bypass on `main`).
2. Branch model migration: delete remote `develop`, switch default branch to `main`.

## Note
The first real release commit will show a large CHANGELOG footer diff — `patchChangelog` generates link refs for every historical version on its first run. One-time cosmetic churn; self-maintaining afterward.