### PR TITLE
Update Yospace SDK integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+## Repository Guidance
+
+- Use US spelling in code, documentation, comments, and commit messages. Prefer terms like `initialization` over `initialisation`.
+- Changelog entries under `Fixed` must describe the user-visible issue that was fixed, not the technical solution.
+- Keep code comments and changelog entries concise.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `YospaceAssetType.LINEAR_START_OVER` playback now uses the initialized Yospace session playback URL and reports a stream-start-relative DVR live playhead, allowing live ad breaks to be recognized correctly
 - `YospaceConfig.liveInitialisationType` now also controls `LINEAR_START_OVER`/`SessionDVRLive` initialisation
 - Live proxy initialisation now uses the Yospace `SessionFactory` path expected by validation tooling
+- Player stalls are now reported to the Yospace SDK as `STALL`/`CONTINUE` events
 
 ### Deprecated
 - `YospaceAssetType.LINEAR`; use `YospaceAssetType.LINEAR_START_OVER` for DVR live playback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - `YospaceConfig.yospaceDebugMode` to enable Yospace SDK validation or full debug logging
+- Yospace warning codes for no-analytics, initialization, and analytics-session issues
 
 ### Changed
 - Upgraded Yospace Ad Management SDK from `3.3.3` to `3.11.2`
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Ad breaks were not correctly reported if `YospaceAssetType.LINEAR_START_OVER` was used
 - `YospaceConfig.liveInitializationType` had no effect for `YospaceAssetType.LINEAR_START_OVER`
 - Yospace validation could reject live proxy sessions as not factory-created
+- Recoverable Yospace session failures could crash before fallback playback
 
 ### Deprecated
 - `YospaceAssetType.LINEAR`: Use `YospaceAssetType.LINEAR_START_OVER` for DVR live playback instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Ad breaks were not correctly reported if `YospaceAssetType.LINEAR_START_OVER` was used
 - `YospaceConfig.liveInitializationType` had no effect for `YospaceAssetType.LINEAR_START_OVER`
-- Yospace validation could reject live proxy sessions as not factory-created
+- Live proxy sessions could fail Yospace validation
 - Recoverable Yospace session failures could crash before fallback playback
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `YospaceAssetType.LINEAR_START_OVER` playback now uses the initialized Yospace session playback URL and reports a stream-start-relative DVR live playhead, allowing live ad breaks to be recognized correctly
 - `YospaceConfig.liveInitialisationType` now also controls `LINEAR_START_OVER`/`SessionDVRLive` initialisation
 - Live proxy initialisation now uses the Yospace `SessionFactory` path expected by validation tooling
-- Player stalls are now reported to the Yospace SDK as `STALL`/`CONTINUE` events
 
 ### Deprecated
 - `YospaceAssetType.LINEAR`; use `YospaceAssetType.LINEAR_START_OVER` for DVR live playback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Ad breaks were not correctly reported if `YospaceAssetType.LINEAR_START_OVER` was used
-- `YospaceConfig.liveInitialisationType` had no effect for `YospaceAssetType.LINEAR_START_OVER`
-- Live proxy initialization used a wrong initialization method of the Yospace SDK
+- `YospaceConfig.liveInitializationType` had no effect for `YospaceAssetType.LINEAR_START_OVER`
+- Yospace validation could reject live proxy sessions as not factory-created
 
 ### Deprecated
 - `YospaceAssetType.LINEAR`: Use `YospaceAssetType.LINEAR_START_OVER` for DVR live playback instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-- `YospaceConfig.yospaceDebugMode` to enable Yospace SDK validation or full debug logging without exposing Yospace SDK APIs to consumers
+- `YospaceConfig.yospaceDebugMode` to enable Yospace SDK validation or full debug logging
 
 ### Changed
 - Upgraded Yospace Ad Management SDK from `3.3.3` to `3.11.2`
-- `YospaceAssetType.LINEAR_START_OVER` now initialises a `SessionDVRLive` session (the removed `SessionNLSO` has no direct replacement)
+- `YospaceAssetType.LINEAR_START_OVER` now uses the recommended DVRLive session mode
 
 ### Fixed
-- `YospaceAssetType.LINEAR_START_OVER` playback now uses the initialized Yospace session playback URL and reports a stream-start-relative DVR live playhead, allowing live ad breaks to be recognized correctly
-- `YospaceConfig.liveInitialisationType` now also controls `LINEAR_START_OVER`/`SessionDVRLive` initialisation
-- Live proxy initialisation now uses the Yospace `SessionFactory` path expected by validation tooling
+- Ad breaks were not correctly reported if `YospaceAssetType.LINEAR_START_OVER` was used
+- `YospaceConfig.liveInitialisationType` had no effect for `YospaceAssetType.LINEAR_START_OVER`
+- Live proxy initialization used a wrong initialization method of the Yospace SDK
 
 ### Deprecated
-- `YospaceAssetType.LINEAR`; use `YospaceAssetType.LINEAR_START_OVER` for DVR live playback
+- `YospaceAssetType.LINEAR`: Use `YospaceAssetType.LINEAR_START_OVER` for DVR live playback instead.
 
 ### Removed
-- Dropped the separate `com.yospace:admanagement-util` dependency; the SDK now provides the required utilities
-- `YospaceConfig.connectTimeout` is no longer forwarded to the Yospace SDK, which dropped the setting (only `requestTimeout`/`resourceTimeout` remain)
+- `com.yospace:admanagement-util` dependency as the Yospace SDK now provides the required utilities directly
+- `YospaceConfig.connectTimeout` as the Yospace SDK does not provide this underlying setting anymore
 
 ## [2.1.0] - 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `YospaceConfig.liveInitialisationType` now also controls `LINEAR_START_OVER`/`SessionDVRLive` initialisation
 - Live proxy initialisation now uses the Yospace `SessionFactory` path expected by validation tooling
 
+### Deprecated
+- `YospaceAssetType.LINEAR`; use `YospaceAssetType.LINEAR_START_OVER` for DVR live playback
+
 ### Removed
 - Dropped the separate `com.yospace:admanagement-util` dependency; the SDK now provides the required utilities
 - `YospaceConfig.connectTimeout` is no longer forwarded to the Yospace SDK, which dropped the setting (only `requestTimeout`/`resourceTimeout` remain)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - `YospaceAssetType.LINEAR_START_OVER` playback now uses the initialized Yospace session playback URL and reports a stream-start-relative DVR live playhead, allowing live ad breaks to be recognized correctly
+- `YospaceConfig.liveInitialisationType` now also controls `LINEAR_START_OVER`/`SessionDVRLive` initialisation
 
 ### Removed
 - Dropped the separate `com.yospace:admanagement-util` dependency; the SDK now provides the required utilities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 - `com.yospace:admanagement-util` dependency as the Yospace SDK now provides the required utilities directly
-- `YospaceConfig.connectTimeout` as the Yospace SDK does not provide this underlying setting anymore
+- `YospaceConfig.readTimeout` and `YospaceConfig.connectTimeout` as the Yospace SDK no longer exposes these settings
 
 ## [2.1.0] - 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `YospaceConfig.yospaceDebugMode` to enable Yospace SDK validation or full debug logging without exposing Yospace SDK APIs to consumers
+
 ### Changed
 - Upgraded Yospace Ad Management SDK from `3.3.3` to `3.11.2`
 - `YospaceAssetType.LINEAR_START_OVER` now initialises a `SessionDVRLive` session (the removed `SessionNLSO` has no direct replacement)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Upgraded Yospace Ad Management SDK from `3.3.3` to `3.11.2`
 - `YospaceAssetType.LINEAR_START_OVER` now initialises a `SessionDVRLive` session (the removed `SessionNLSO` has no direct replacement)
 
+### Fixed
+- `YospaceAssetType.LINEAR_START_OVER` playback now uses the initialized Yospace session playback URL and reports a stream-start-relative DVR live playhead, allowing live ad breaks to be recognized correctly
+
 ### Removed
 - Dropped the separate `com.yospace:admanagement-util` dependency; the SDK now provides the required utilities
 - `YospaceConfig.connectTimeout` is no longer forwarded to the Yospace SDK, which dropped the setting (only `requestTimeout`/`resourceTimeout` remain)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Upgraded Yospace Ad Management SDK from `3.3.3` to `3.11.2`
+- `YospaceAssetType.LINEAR_START_OVER` now initialises a `SessionDVRLive` session (the removed `SessionNLSO` has no direct replacement)
+
+### Removed
+- Dropped the separate `com.yospace:admanagement-util` dependency; the SDK now provides the required utilities
+- `YospaceConfig.connectTimeout` is no longer forwarded to the Yospace SDK, which dropped the setting (only `requestTimeout`/`resourceTimeout` remain)
+
 ## [2.1.0] - 2026-06-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - `YospaceAssetType.LINEAR_START_OVER` playback now uses the initialized Yospace session playback URL and reports a stream-start-relative DVR live playhead, allowing live ad breaks to be recognized correctly
 - `YospaceConfig.liveInitialisationType` now also controls `LINEAR_START_OVER`/`SessionDVRLive` initialisation
+- Live proxy initialisation now uses the Yospace `SessionFactory` path expected by validation tooling
 
 ### Removed
 - Dropped the separate `com.yospace:admanagement-util` dependency; the SDK now provides the required utilities

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ val yospaceConfig = YospaceConfig(
     connectTimeout = 25_000,
     requestTimeout = 25_000,
     liveInitialisationType = YospaceLiveInitialisationType.DIRECT,
-    isDebug = true
+    isDebug = true,
+    yospaceDebugMode = YospaceDebugMode.VALIDATION
 )
 
 // Create the BitmovinYospacePlayer

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ val truexConfig = TruexConfig(viewGroup = playerView)
 player.load(sourceConfig, yospaceSourceConfig, truexConfig)
 ```
 
+When uploading live validation logs to Yospace, select the same initialisation type in the validation tool as configured in `YospaceConfig.liveInitialisationType`.
+
 #### Ad Tracking Events
 The `BitmovinYospacePlayer` fires events through the standard Bitmovin Player event API.
 Subscribe with the `on<EventType> { }` extension. These are the ad related events you will

--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ The following example creates a `BitmovinYospacePlayer` and loads a `YospaceSour
 // Create a YospaceConfig
 val yospaceConfig = YospaceConfig(
     userAgent = "userAgent",
-    readTimeout = 25_000,
-    connectTimeout = 25_000,
     requestTimeout = 25_000,
     liveInitializationType = YospaceLiveInitializationType.DIRECT,
     isDebug = true,

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ val yospaceConfig = YospaceConfig(
     readTimeout = 25_000,
     connectTimeout = 25_000,
     requestTimeout = 25_000,
-    liveInitialisationType = YospaceLiveInitialisationType.DIRECT,
+    liveInitializationType = YospaceLiveInitializationType.DIRECT,
     isDebug = true,
     yospaceDebugMode = YospaceDebugMode.VALIDATION
 )
@@ -114,7 +114,7 @@ val truexConfig = TruexConfig(viewGroup = playerView)
 player.load(sourceConfig, yospaceSourceConfig, truexConfig)
 ```
 
-When uploading live validation logs to Yospace, select the same initialisation type in the validation tool as configured in `YospaceConfig.liveInitialisationType`.
+When uploading live validation logs to Yospace, select the same initialization type in the validation tool as configured in `YospaceConfig.liveInitializationType`.
 
 #### Ad Tracking Events
 The `BitmovinYospacePlayer` fires events through the standard Bitmovin Player event API.

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,8 +17,7 @@ ext {
     ]
 
     yospaceDependencies = [
-            adManagementSDK: "com.yospace:admanagement-sdk:3.3.3",
-            adManagementUtil: "com.yospace:admanagement-util:2.15.9"
+            adManagementSDK: "com.yospace:admanagement-sdk:3.11.2"
     ]
 
     truexDependencies = [

--- a/yospace/build.gradle
+++ b/yospace/build.gradle
@@ -49,7 +49,6 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation yospaceDependencies.adManagementSDK
-    implementation yospaceDependencies.adManagementUtil
     annotationProcessor 'androidx.lifecycle:lifecycle-common-java8:2.3.1'
 
     testImplementation testDependencies.junitAPI

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinTruexAdRenderer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinTruexAdRenderer.kt
@@ -30,7 +30,7 @@ class BitmovinTruexAdRenderer(
 
     fun renderAd(ad: Advert, adBreakPosition: AdBreakPosition) {
         this.adBreakPosition = adBreakPosition
-        this.interactiveUnit = ad.interactiveCreative
+        this.interactiveUnit = ad.interactiveCreatives.firstOrNull()
 
         interactiveUnit?.let { interactiveUnit ->
             BitLog.d("Rendering ad: ${interactiveUnit.source}")

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinTruexAdRenderer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinTruexAdRenderer.kt
@@ -123,7 +123,7 @@ class BitmovinTruexAdRenderer(
         }
 
         addEventListener(TruexAdRendererConstants.USER_CANCEL) {
-            BitLog.d("Ad cancelled")
+            BitLog.d("Ad canceled")
         }
 
         addEventListener(TruexAdRendererConstants.POPUP_WEBSITE) {

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -384,11 +384,13 @@ open class BitmovinYospacePlayer(
         }
 
         player.on<PlayerEvent.StallEnded> {
-            BitLog.d("Buffering end: $yospaceTime")
+            BitLog.d("Sending CONTINUE event: $yospaceTime")
+            yospaceSession?.onPlayerEvent(YoPlayerEvent.CONTINUE, yospacePlayheadMs())
         }
 
         player.on<PlayerEvent.StallStarted> {
-            BitLog.d("Buffering start: $yospaceTime")
+            BitLog.d("Sending STALL event: $yospaceTime")
+            yospaceSession?.onPlayerEvent(YoPlayerEvent.STALL, yospacePlayheadMs())
         }
 
         player.on<PlayerEvent.Metadata> { metadataEvent ->

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -21,6 +21,7 @@ import com.bitmovin.player.api.source.SourceType as MediaSourceType
 import com.bitmovin.player.api.source.*
 import com.bitmovin.player.integration.yospace.config.TruexConfig
 import com.bitmovin.player.integration.yospace.config.YospaceConfig
+import com.bitmovin.player.integration.yospace.config.YospaceDebugMode
 import com.bitmovin.player.integration.yospace.config.YospaceSourceConfig
 import com.yospace.admanagement.*
 import com.yospace.admanagement.TimedMetadata
@@ -117,11 +118,7 @@ open class BitmovinYospacePlayer(
         sessionProperties.requestTimeout = yospaceConfig.requestTimeout
         sessionProperties.userAgent = yospaceConfig.userAgent
 
-        // setDebugFlags is now static on SessionProperties; DEBUG_ID3TAG/DEBUG_RAW_XML were dropped
-        // and DEBUG_HTTP is now DEBUG_HTTP_REQUESTS.
-        SessionProperties.setDebugFlags(
-            YoLog.DEBUG_POLLING or YoLog.DEBUG_PARSING or YoLog.DEBUG_REPORTS or YoLog.DEBUG_HTTP_REQUESTS
-        )
+        SessionProperties.setDebugFlags(yospaceConfig.yospaceDebugMode.toYospaceDebugFlags())
 
         yospaceSessionProperties = sessionProperties
 
@@ -804,6 +801,16 @@ open class BitmovinYospacePlayer(
         type === "EMSG" -> convertEmsgToId3()
         type === "ID3" -> processId3()
         else -> null
+    }
+
+    private fun YospaceDebugMode.toYospaceDebugFlags() = when (this) {
+        YospaceDebugMode.NONE -> 0
+        YospaceDebugMode.VALIDATION -> YoLog.DEBUG_VALIDATION
+        YospaceDebugMode.ALL -> YoLog.DEBUG_POLLING or
+            YoLog.DEBUG_PARSING or
+            YoLog.DEBUG_REPORTS or
+            YoLog.DEBUG_HTTP_REQUESTS or
+            YoLog.DEBUG_VALIDATION
     }
 
     private fun PlayerEvent.Metadata.processId3(): TimedMetadata? {

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -166,17 +166,23 @@ open class BitmovinYospacePlayer(
     }
 
     private fun loadStartOver(originalUrl: String, properties: SessionProperties) {
-        // SessionNLSO was removed in SDK 3.4.0; SessionDVRLive is the positional seekable-live replacement.
-        SessionDVRLive.create(
-            originalUrl, properties
-        ) { event: Event<Session> ->
-            // Playback must use the URL for this initialized Yospace session.
-            onSessionInitialized(
-                event.payload,
-                "Yospace analytics session DVRLive initialised"
-            )
-            if (event.payload.sessionState == Session.SessionState.INITIALISED) {
-                startPlayback(MediaSourceType.Hls, event.payload.playbackUrl)
+        when (yospaceConfig.liveInitialisationType) {
+            YospaceLiveInitialisationType.PROXY -> {
+                val playbackUrl = SessionFactory.create(
+                    originalUrl,
+                    Session.SessionMode.DVRLIVE,
+                    properties,
+                    sessionListener
+                )
+                startPlayback(MediaSourceType.Hls, playbackUrl)
+            }
+            YospaceLiveInitialisationType.DIRECT -> {
+                // SessionNLSO was removed in SDK 3.4.0; SessionDVRLive is the positional seekable-live replacement.
+                SessionDVRLive.create(
+                    originalUrl,
+                    properties,
+                    sessionListener
+                )
             }
         }
     }
@@ -502,10 +508,8 @@ open class BitmovinYospacePlayer(
                 yospaceSession?.addAnalyticObserver(analyticEventListener)
                 yospaceSession?.setPlaybackPolicyHandler(yospacePlayerPolicy)
 
-                (yospaceSession as? SessionLive)?.let {
-                    if (yospaceConfig.liveInitialisationType != YospaceLiveInitialisationType.DIRECT) {
-                        return@YospaceEventListener
-                    }
+                if (yospaceConfig.liveInitialisationType != YospaceLiveInitialisationType.DIRECT) {
+                    return@YospaceEventListener
                 }
 
                 yospaceSession?.let {

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -132,17 +132,13 @@ open class BitmovinYospacePlayer(
     private fun loadLive(originalUrl: String, properties: SessionProperties) =
         when (yospaceConfig.liveInitialisationType) {
             YospaceLiveInitialisationType.PROXY -> {
-                SessionLive.create(
-                    originalUrl, properties
-                ) { event: Event<Session> ->
-                    // Callback made by SessionLive once it has initialised a session on the Yospace CSM
-                    // Retrieve the initialised session
-                    onSessionInitialized(
-                        event.payload,
-                        "Yospace analytics session live initialised"
-                    )
-                }
-                startPlayback(MediaSourceType.Hls, originalUrl)
+                val playbackUrl = SessionFactory.create(
+                    originalUrl,
+                    Session.SessionMode.LIVE,
+                    properties,
+                    sessionListener
+                )
+                startPlayback(MediaSourceType.Hls, playbackUrl)
             }
             YospaceLiveInitialisationType.DIRECT -> SessionLive.create(
                 originalUrl,

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -172,7 +172,6 @@ open class BitmovinYospacePlayer(
                 startPlayback(MediaSourceType.Hls, playbackUrl)
             }
             YospaceLiveInitialisationType.DIRECT -> {
-                // SessionNLSO was removed in SDK 3.4.0; SessionDVRLive is the positional seekable-live replacement.
                 SessionDVRLive.create(
                     originalUrl,
                     properties,

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -130,8 +130,8 @@ open class BitmovinYospacePlayer(
     }
 
     private fun loadLive(originalUrl: String, properties: SessionProperties) =
-        when (yospaceConfig.liveInitialisationType) {
-            YospaceLiveInitialisationType.PROXY -> {
+        when (yospaceConfig.liveInitializationType) {
+            YospaceLiveInitializationType.PROXY -> {
                 val playbackUrl = SessionFactory.create(
                     originalUrl,
                     Session.SessionMode.LIVE,
@@ -140,7 +140,7 @@ open class BitmovinYospacePlayer(
                 )
                 startPlayback(MediaSourceType.Hls, playbackUrl)
             }
-            YospaceLiveInitialisationType.DIRECT -> SessionLive.create(
+            YospaceLiveInitializationType.DIRECT -> SessionLive.create(
                 originalUrl,
                 properties,
                 sessionListener
@@ -151,19 +151,17 @@ open class BitmovinYospacePlayer(
         SessionVOD.create(
             originalUrl, properties
         ) { event: Event<Session> ->
-            // Callback made by Session once it has initialised a session on the Yospace CSM
-            // Retrieve the initialised session
             onSessionInitialized(
                 event.payload,
-                "Yospace analytics session VOD initialised"
+                "Yospace analytics session VOD initialized"
             )
             startPlayback(MediaSourceType.Hls, event.payload.playbackUrl)
         }
     }
 
     private fun loadStartOver(originalUrl: String, properties: SessionProperties) {
-        when (yospaceConfig.liveInitialisationType) {
-            YospaceLiveInitialisationType.PROXY -> {
+        when (yospaceConfig.liveInitializationType) {
+            YospaceLiveInitializationType.PROXY -> {
                 val playbackUrl = SessionFactory.create(
                     originalUrl,
                     Session.SessionMode.DVRLIVE,
@@ -172,7 +170,7 @@ open class BitmovinYospacePlayer(
                 )
                 startPlayback(MediaSourceType.Hls, playbackUrl)
             }
-            YospaceLiveInitialisationType.DIRECT -> {
+            YospaceLiveInitializationType.DIRECT -> {
                 SessionDVRLive.create(
                     originalUrl,
                     properties,
@@ -495,7 +493,6 @@ open class BitmovinYospacePlayer(
     ///////////////////////////////////////////////////////////////
 
     private val sessionListener: YospaceEventListener<Session> = YospaceEventListener { event ->
-        // Retrieve the initialised session
         yospaceSession = event.payload
         BitLog.d("Session state: ${yospaceSession?.sessionState?.name}, result code: ${yospaceSession?.resultCode}")
 
@@ -506,7 +503,7 @@ open class BitmovinYospacePlayer(
                 yospaceSession?.addAnalyticObserver(analyticEventListener)
                 yospaceSession?.setPlaybackPolicyHandler(yospacePlayerPolicy)
 
-                if (yospaceConfig.liveInitialisationType != YospaceLiveInitialisationType.DIRECT) {
+                if (yospaceConfig.liveInitializationType != YospaceLiveInitializationType.DIRECT) {
                     return@YospaceEventListener
                 }
 
@@ -520,7 +517,7 @@ open class BitmovinYospacePlayer(
             )
             else -> handleYospaceSessionFailure(
                 SESSION_NOT_INITIALISED,
-                "Failed to initialise YoSpace stream."
+                "Failed to initialize YoSpace stream."
             )
         }
     }

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -29,6 +29,7 @@ import com.yospace.admanagement.PlaybackEventHandler.PlayerEvent as YoPlayerEven
 import com.yospace.admanagement.Session.SessionProperties
 import com.yospace.admanagement.util.YoLog
 import kotlin.math.roundToInt
+import kotlin.math.roundToLong
 import kotlin.properties.Delegates
 
 // Yospace Error/Warning Codes
@@ -172,15 +173,15 @@ open class BitmovinYospacePlayer(
         SessionDVRLive.create(
             originalUrl, properties
         ) { event: Event<Session> ->
-            // Callback made by Session once it has initialised a session on the Yospace CSM
-            // Retrieve the initialised session
+            // Playback must use the URL for this initialized Yospace session.
             onSessionInitialized(
                 event.payload,
                 "Yospace analytics session DVRLive initialised"
             )
-            yospaceSession = event.payload
+            if (event.payload.sessionState == Session.SessionState.INITIALISED) {
+                startPlayback(MediaSourceType.Hls, event.payload.playbackUrl)
+            }
         }
-        startPlayback(MediaSourceType.Hls, originalUrl)
     }
 
     private fun onSessionInitialized(session: Session, message: String) {
@@ -249,6 +250,15 @@ open class BitmovinYospacePlayer(
     }
 
     fun currentTimeWithAds(): Double = player.currentTime
+
+    /**
+     * Yospace expects milliseconds from the fixed timeline origin where the first media segment
+     * was available to this session. This anchors ad-break matching and analytics for DVR live.
+     */
+    private fun yospacePlayheadMs(playbackTime: Double = currentTimeWithAds()): Long =
+        ((playbackTime + player.playbackTimeOffsetToRelativeTime) * 1000)
+            .roundToLong()
+            .coerceAtLeast(0)
 
     override fun seek(time: Double) {
         adTimeline?.let {
@@ -331,12 +341,12 @@ open class BitmovinYospacePlayer(
             BitLog.d("Sending PLAYSTART event: $yospaceTime")
             yospaceSessionStatus = SessionStatus.INITIALIZED
 
-            // SessionLive has a specialized onPlaybackStart(playhead) method that starts the analytic poller.
-            // NOTICE: It differs from the one in class Session, which does not add poller.
-            if (this.yospaceSourceConfig?.assetType == YospaceAssetType.LINEAR) {
-                (yospaceSession as? SessionLive)?.onPlaybackStart(yospaceTime.toLong())
-            } else {
-                yospaceSession?.onPlaybackStart()
+            // Live sessions need the playhead overload to start the analytic poller.
+            when (yospaceSourceConfig?.assetType) {
+                YospaceAssetType.LINEAR -> (yospaceSession as? SessionLive)?.onPlaybackStart(yospacePlayheadMs())
+                YospaceAssetType.LINEAR_START_OVER ->
+                    (yospaceSession as? SessionDVRLive)?.onPlaybackStart(yospacePlayheadMs())
+                else -> yospaceSession?.onPlaybackStart()
             }
         }
 
@@ -344,7 +354,7 @@ open class BitmovinYospacePlayer(
             BitLog.d("Sending PAUSED event: $yospaceTime")
             isLiveAdPaused = player.isLive && isYospaceAd()
 
-            yospaceSession?.onPlayerEvent(YoPlayerEvent.PAUSE, yospaceTime.toLong())
+            yospaceSession?.onPlayerEvent(YoPlayerEvent.PAUSE, yospacePlayheadMs())
         }
 
         player.on<PlayerEvent.Playing> {
@@ -354,7 +364,7 @@ open class BitmovinYospacePlayer(
 
         player.on<PlayerEvent.PlaybackFinished> {
             BitLog.d("Sending STOPPED event: $yospaceTime")
-            yospaceSession?.onPlayerEvent(YoPlayerEvent.STOP, yospaceTime.toLong())
+            yospaceSession?.onPlayerEvent(YoPlayerEvent.STOP, yospacePlayheadMs())
         }
 
         player.on<SourceEvent.Loaded> {
@@ -403,9 +413,10 @@ open class BitmovinYospacePlayer(
         player.on<PlayerEvent.TimeChanged> {
             val currentTime = getCurrentTimeMinusAd()
             val timeChangedEvent = PlayerEvent.TimeChanged(currentTime)
-            yospaceSession?.onPlayheadUpdate((currentTime * 1000).toLong())
 
-            if (yospaceSession as? SessionLive != null) {
+            yospaceSession?.onPlayheadUpdate(yospacePlayheadMs())
+
+            if (yospaceSession as? SessionLive != null || yospaceSession as? SessionDVRLive != null) {
                 // Live session
                 val adSkippedEvent = PlayerEvent.AdSkipped(activeAd)
                 handler.post {

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -27,11 +27,7 @@ import com.yospace.admanagement.TimedMetadata
 import com.yospace.admanagement.EventListener as YospaceEventListener
 import com.yospace.admanagement.PlaybackEventHandler.PlayerEvent as YoPlayerEvent
 import com.yospace.admanagement.Session.SessionProperties
-import com.yospace.admanagement.Session.SessionProperties.addDebugFlags
-import com.yospace.hls.player.PlaybackState
-import com.yospace.hls.player.PlayerState
-import com.yospace.util.YoLog
-import com.yospace.util.event.EventSourceImpl
+import com.yospace.admanagement.util.YoLog
 import kotlin.math.roundToInt
 import kotlin.properties.Delegates
 
@@ -53,8 +49,7 @@ open class BitmovinYospacePlayer(
 ) : Player by player {
 
     private var yospaceSession: Session? = null
-    private val yospaceStateSource = EventSourceImpl<PlayerState>()
-    private val yospaceMetadataSource = EventSourceImpl<TimedMetadata>()
+    private val yospaceMetadataSource = EventSource<TimedMetadata>()
     private val yospacePlayerPolicy: YospacePlayerPolicy = YospacePlayerPolicy(DefaultBitmovinYospacePlayerPolicy(this))
     private val yospaceEventEmitter = YospaceEventEmitter()
     private var yospaceSessionProperties: Session.SessionProperties? = null
@@ -116,19 +111,18 @@ open class BitmovinYospacePlayer(
             return
         }
 
+        // connectTimeout has no SDK equivalent since 3.5.0; only requestTimeout/resourceTimeout remain.
         val sessionProperties = SessionProperties()
-        sessionProperties.connectTimeout = yospaceConfig.connectTimeout
         sessionProperties.requestTimeout = yospaceConfig.requestTimeout
         sessionProperties.userAgent = yospaceConfig.userAgent
-        // SessionProperties.setDebugFlags(com.yospace.admanagement.util.YoLog.DEBUG_VALIDATION);
+
+        // setDebugFlags is now static on SessionProperties; DEBUG_ID3TAG/DEBUG_RAW_XML were dropped
+        // and DEBUG_HTTP is now DEBUG_HTTP_REQUESTS.
+        SessionProperties.setDebugFlags(
+            YoLog.DEBUG_POLLING or YoLog.DEBUG_PARSING or YoLog.DEBUG_REPORTS or YoLog.DEBUG_HTTP_REQUESTS
+        )
 
         yospaceSessionProperties = sessionProperties
-            .apply {
-                addDebugFlags(
-                    YoLog.DEBUG_POLLING or YoLog.DEBUG_ID3TAG or YoLog.DEBUG_PARSING
-                            or YoLog.DEBUG_REPORTS or YoLog.DEBUG_HTTP or YoLog.DEBUG_RAW_XML
-                )
-            }
 
         when (yospaceSourceConfig.assetType) {
             YospaceAssetType.LINEAR -> loadLive(originalUrl, yospaceSessionProperties!!)
@@ -174,14 +168,15 @@ open class BitmovinYospacePlayer(
     }
 
     private fun loadStartOver(originalUrl: String, properties: SessionProperties) {
-        SessionNLSO.create(
+        // SessionNLSO was removed in SDK 3.4.0; SessionDVRLive is the positional seekable-live replacement.
+        SessionDVRLive.create(
             originalUrl, properties
         ) { event: Event<Session> ->
             // Callback made by Session once it has initialised a session on the Yospace CSM
             // Retrieve the initialised session
             onSessionInitialized(
                 event.payload,
-                "Yospace analytics session NLSO initialised"
+                "Yospace analytics session DVRLive initialised"
             )
             yospaceSession = event.payload
         }
@@ -189,8 +184,8 @@ open class BitmovinYospacePlayer(
     }
 
     private fun onSessionInitialized(session: Session, message: String) {
-        when (session.sessionResult) {
-            Session.SessionResult.INITIALISED -> {
+        when (session.sessionState) {
+            Session.SessionState.INITIALISED -> {
                 yospaceSession = session
                 session.addAnalyticObserver(analyticEventListener)
                 session.setPlaybackPolicyHandler(yospacePlayerPolicy)
@@ -198,8 +193,8 @@ open class BitmovinYospacePlayer(
                 return
             }
             else -> {
-                BitLog.e("Session Initialization failed with result: %s"
-                    .format(session.sessionResult.toString()))
+                BitLog.e("Session Initialization failed with state: %s"
+                    .format(session.sessionState.toString()))
             }
         }
     }
@@ -348,36 +343,26 @@ open class BitmovinYospacePlayer(
         player.on<PlayerEvent.Paused> {
             BitLog.d("Sending PAUSED event: $yospaceTime")
             isLiveAdPaused = player.isLive && isYospaceAd()
-            yospaceStateSource.notify(PlayerState(PlaybackState.PAUSED, yospaceTime, false))
 
             yospaceSession?.onPlayerEvent(YoPlayerEvent.PAUSE, yospaceTime.toLong())
         }
 
         player.on<PlayerEvent.Playing> {
             BitLog.d("Sending PLAYING event: $yospaceTime")
-            yospaceStateSource.notify(PlayerState(PlaybackState.PLAYING, yospaceTime, false))
-
             isPlayingEventSent = true
         }
 
         player.on<PlayerEvent.PlaybackFinished> {
             BitLog.d("Sending STOPPED event: $yospaceTime")
-            yospaceStateSource.notify(PlayerState(PlaybackState.STOPPED, yospaceTime, false))
-
             yospaceSession?.onPlayerEvent(YoPlayerEvent.STOP, yospaceTime.toLong())
         }
 
         player.on<SourceEvent.Loaded> {
-            BitLog.d("Sending INITIALISING event: $yospaceTime")
-            yospaceStateSource.notify(PlayerState(PlaybackState.INITIALISING, yospaceTime, false))
+            BitLog.d("Source loaded: $yospaceTime")
             (yospaceSession as? SessionVOD)?.let {
-                // SessionVOD.adBreaks is deprecated in the Yospace SDK; migrating away from it is a
-                // separate Yospace API change.
-                @Suppress("DEPRECATION")
-                val adBreaks = it.adBreaks.toAdBreaks()
+                val adBreaks = it.getAdBreaks(com.yospace.admanagement.AdBreak.BreakType.LINEAR).toAdBreaks()
                 adTimeline = AdTimeline(adBreaks)
-                @Suppress("DEPRECATION")
-                BitLog.d("Ad breaks: ${it.adBreaks}")
+                BitLog.d("Ad breaks: ${it.getAdBreaks(com.yospace.admanagement.AdBreak.BreakType.LINEAR)}")
                 BitLog.d(adTimeline.toString())
             }
         }
@@ -385,25 +370,16 @@ open class BitmovinYospacePlayer(
         player.on<SourceEvent.Unloaded> {
             if (yospaceSessionStatus !== SessionStatus.NOT_INITIALIZED) {
                 BitLog.d("Sending STOPPED event: $yospaceTime")
-                yospaceStateSource.notify(PlayerState(PlaybackState.STOPPED, yospaceTime, false))
                 resetYospaceSession()
             }
         }
 
         player.on<PlayerEvent.StallEnded> {
-            BitLog.d("Sending BUFFERING_END event: $yospaceTime")
-            yospaceStateSource.notify(PlayerState(PlaybackState.BUFFERING_END, yospaceTime, false))
+            BitLog.d("Buffering end: $yospaceTime")
         }
 
         player.on<PlayerEvent.StallStarted> {
-            BitLog.d("Sending BUFFERING_START event: $yospaceTime")
-            yospaceStateSource.notify(
-                PlayerState(
-                    PlaybackState.BUFFERING_START,
-                    yospaceTime,
-                    false
-                )
-            )
+            BitLog.d("Buffering start: $yospaceTime")
         }
 
         player.on<PlayerEvent.Metadata> { metadataEvent ->
@@ -446,23 +422,16 @@ open class BitmovinYospacePlayer(
                 }
             } else {
                 // Non-live session
-                yospaceStateSource.notify(
-                    PlayerState(
-                        PlaybackState.PLAYHEAD_UPDATE,
-                        yospaceTime,
-                        false
-                    )
-                )
                 handler.post { yospaceEventEmitter.emit(timeChangedEvent) }
             }
         }
 
         player.on<PlayerEvent.FullscreenEnter> {
-            yospaceSession?.onViewSizeChange(PlaybackEventHandler.ViewSize.MAXIMISED)
+            yospaceSession?.onViewSizeChange(PlaybackEventHandler.ViewSize.EXPANDED)
         }
 
         player.on<PlayerEvent.FullscreenExit> {
-            yospaceSession?.onViewSizeChange(PlaybackEventHandler.ViewSize.MINIMISED)
+            yospaceSession?.onViewSizeChange(PlaybackEventHandler.ViewSize.COLLAPSED)
         }
     }
 
@@ -516,10 +485,10 @@ open class BitmovinYospacePlayer(
     private val sessionListener: YospaceEventListener<Session> = YospaceEventListener { event ->
         // Retrieve the initialised session
         yospaceSession = event.payload
-        BitLog.d("Session state: ${yospaceSession?.sessionResult?.name}, result code: ${yospaceSession?.resultCode}")
+        BitLog.d("Session state: ${yospaceSession?.sessionState?.name}, result code: ${yospaceSession?.resultCode}")
 
-        when (yospaceSession?.sessionResult) {
-            Session.SessionResult.INITIALISED -> {
+        when (yospaceSession?.sessionState) {
+            Session.SessionState.INITIALISED -> {
                 BitLog.d("YoSpace session Initialized: url=${yospaceSession?.playbackUrl}")
 
                 yospaceSession?.addAnalyticObserver(analyticEventListener)
@@ -535,18 +504,14 @@ open class BitmovinYospacePlayer(
                     startPlayback(MediaSourceType.Hls, it.playbackUrl)
                 }
             }
-            Session.SessionResult.FAILED -> handleYospaceSessionFailure(
+            Session.SessionState.FAILED, Session.SessionState.NO_ANALYTICS -> handleYospaceSessionFailure(
                 SESSION_NO_ANALYTICS,
                 "Source URL does not refer to a YoSpace stream"
             )
-            Session.SessionResult.NOT_INITIALISED -> handleYospaceSessionFailure(
+            else -> handleYospaceSessionFailure(
                 SESSION_NOT_INITIALISED,
                 "Failed to initialise YoSpace stream."
             )
-            else -> {
-                BitLog.e("Yospace Session Initialization failed with result: %s"
-                    .format(yospaceSession?.sessionResult.toString()))
-            }
         }
     }
 
@@ -589,7 +554,7 @@ open class BitmovinYospacePlayer(
 
     private val analyticEventListener: AnalyticEventObserver = object : AnalyticEventObserver {
 
-        override fun onAdvertBreakStart(adBreak: com.yospace.admanagement.AdBreak?) {
+        override fun onAdvertBreakStart(adBreak: com.yospace.admanagement.AdBreak?, session: Session) {
             BitLog.d("YoSpace onAdvertBreakStart")
 
             val absoluteTime = currentTimeWithAds()
@@ -612,11 +577,13 @@ open class BitmovinYospacePlayer(
             handler.post { yospaceEventEmitter.emit(adBreakStartedEvent) }
         }
 
-        override fun onAdvertStart(advert: Advert) {
+        override fun onAdvertStart(advert: Advert, session: Session) {
             BitLog.d("YoSpace onAdvertStart")
 
+            val interactiveCreative = advert.interactiveCreatives.firstOrNull()
+
             // Render TrueX ad
-            if (advert.interactiveCreative != null) {
+            if (interactiveCreative != null) {
                 truexRenderer?.let {
                     BitLog.d("TrueX ad found: $advert")
 
@@ -647,7 +614,7 @@ open class BitmovinYospacePlayer(
                         adAbsoluteStart = absoluteTime
                         adRelativeStart = activeAdBreak?.relativeStart ?: absoluteTime
                     } else /* VOD */ {
-                        adAbsoluteStart = advert.start?.div(1000.0) ?: absoluteTime
+                        adAbsoluteStart = advert.start.div(1000.0)
                         adRelativeStart = adTimeline?.absoluteToRelative(adAbsoluteStart)
                             ?: adAbsoluteStart
                     }
@@ -655,7 +622,7 @@ open class BitmovinYospacePlayer(
                     advert.toAd(adAbsoluteStart, adRelativeStart)
                 }
 
-            val companionAds = advert.interactiveCreative?.nonLinearCreatives?.map { creative ->
+            val companionAds = interactiveCreative?.nonLinearCreatives?.map { creative ->
                 val resource = creative.getResource(Resource.ResourceType.HTML)?.let {
                     CompanionAdResource(it.stringData, CompanionAdType.HTML)
                 } ?: creative.getResource(Resource.ResourceType.STATIC)?.let {
@@ -677,11 +644,11 @@ open class BitmovinYospacePlayer(
             handler.post {
                 yospaceEventEmitter.emit(
                     YospaceAdStartedEvent(
-                        clientType = toAdType(advert.adType?:"Yospace"),
+                        clientType = toAdType(advert.adType ?: "Yospace"),
                         clickThroughUrl = advert.linearCreative?.clickThroughUrl.orEmpty(),
-                        indexInQueue = advert.sequence ?: 0,
-                        duration = advert.duration.div(1000.0) ?: 0.0,
-                        timeOffset = advert.start.div(1000.0) ?: 0.0,
+                        indexInQueue = advert.sequence,
+                        duration = advert.duration.div(1000.0),
+                        timeOffset = advert.start.div(1000.0),
                         position = "position",
                         skipOffset = 0.0,
                         ad = activeAd,
@@ -691,7 +658,7 @@ open class BitmovinYospacePlayer(
             }
         }
 
-        override fun onAdvertEnd() {
+        override fun onAdvertEnd(session: Session) {
             BitLog.d("YoSpace onAdvertEnd")
 
             val adFinishedEvent = PlayerEvent.AdFinished(activeAd)
@@ -700,7 +667,7 @@ open class BitmovinYospacePlayer(
             activeAd = null
         }
 
-        override fun onAdvertBreakEnd() {
+        override fun onAdvertBreakEnd(session: Session) {
             BitLog.d("YoSpace onAdvertBreakEnd")
 
             val adBreakFinishedEvent = PlayerEvent.AdBreakFinished(activeAdBreak)
@@ -708,7 +675,7 @@ open class BitmovinYospacePlayer(
             activeAdBreak = null
         }
 
-        override fun onTrackingEvent(type: String) {
+        override fun onTrackingEvent(type: String, session: Session) {
             BitLog.d("YoSpace onTrackingUrlCalled: $type")
 
             when (type) {
@@ -730,8 +697,28 @@ open class BitmovinYospacePlayer(
             }
         }
 
-        override fun onAnalyticUpdate() {
+        override fun onAnalyticUpdate(session: Session) {
             BitLog.d("YoSpace onAnalyticUpdate event")
+        }
+
+        override fun onEarlyReturn(adBreak: com.yospace.admanagement.AdBreak, session: Session) {
+            BitLog.d("YoSpace onEarlyReturn: ${adBreak.identifier}")
+        }
+
+        override fun onSessionError(error: AnalyticEventObserver.SessionError, session: Session) {
+            BitLog.e("YoSpace onSessionError: $error")
+            handler.post {
+                yospaceEventEmitter.emit(
+                    CustomSourceEvent.Warning(
+                        YospaceWarningCode.fromValue(SESSION_NO_ANALYTICS)!!,
+                        "YoSpace session error: $error"
+                    )
+                )
+            }
+        }
+
+        override fun onTrackingError(error: TrackingErrors.Error, session: Session) {
+            BitLog.e("YoSpace onTrackingError: ${error.toJsonString()}")
         }
     }
 

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -113,7 +113,6 @@ open class BitmovinYospacePlayer(
             return
         }
 
-        // connectTimeout has no SDK equivalent since 3.5.0; only requestTimeout/resourceTimeout remain.
         val sessionProperties = SessionProperties()
         sessionProperties.requestTimeout = yospaceConfig.requestTimeout
         sessionProperties.userAgent = yospaceConfig.userAgent

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -11,7 +11,6 @@ import com.bitmovin.player.api.advertising.AdQuartile
 import com.bitmovin.player.api.advertising.AdSourceType
 import com.bitmovin.player.api.advertising.AdvertisingApi
 import com.bitmovin.player.api.advertising.vast.AdSystem
-import com.bitmovin.player.api.deficiency.SourceErrorCode
 import com.bitmovin.player.api.event.PlayerEvent
 import com.bitmovin.player.api.event.SourceEvent
 import com.bitmovin.player.api.event.on
@@ -527,8 +526,8 @@ open class BitmovinYospacePlayer(
             handler.post {
                 yospaceEventEmitter.emit(
                     CustomSourceEvent.Warning(
-                        YospaceWarningCode.fromValue(errorCode)!!,
-                        "scheduleAd API is not available when playing back a YoSpace asset"
+                        errorCode.toYospaceWarningCode(),
+                        message
                     )
                 )
 
@@ -538,7 +537,14 @@ open class BitmovinYospacePlayer(
             }
         } else {
             BitLog.d("YoSpace session failed, shutting down playback...")
-            handler.post { yospaceEventEmitter.emit(SourceEvent.Error(SourceErrorCode.fromValue(errorCode)!!, message)) }
+            handler.post {
+                yospaceEventEmitter.emit(
+                    CustomSourceEvent.Error(
+                        YospaceErrorCode.fromValue(errorCode) ?: YospaceErrorCode.SessionNotInitialised,
+                        message
+                    )
+                )
+            }
         }
 
     private fun resetYospaceSession() {
@@ -717,7 +723,7 @@ open class BitmovinYospacePlayer(
             handler.post {
                 yospaceEventEmitter.emit(
                     CustomSourceEvent.Warning(
-                        YospaceWarningCode.fromValue(SESSION_NO_ANALYTICS)!!,
+                        YospaceWarningCode.SessionAnalyticsIssue,
                         "YoSpace session error: $error"
                     )
                 )
@@ -732,6 +738,11 @@ open class BitmovinYospacePlayer(
     ///////////////////////////////////////////////////////////////////////////
     // AdBreak Transformation
     ///////////////////////////////////////////////////////////////////////////
+
+    private fun Int.toYospaceWarningCode(): YospaceWarningCode = when (this) {
+        SESSION_NO_ANALYTICS -> YospaceWarningCode.NoAnalytics
+        else -> YospaceWarningCode.SessionInitializationIssue
+    }
 
     private fun toAdType(type: String): AdSourceType = when {
         type == "ima" -> AdSourceType.Ima

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -87,6 +87,7 @@ open class BitmovinYospacePlayer(
     // Playback
     ///////////////////////////////////////////////////////////////
 
+    @Suppress("DEPRECATION")
     fun load(sourceConfig: SourceConfig, yospaceSourceConfig: YospaceSourceConfig, truexConfig: TruexConfig? = null) {
         BitLog.d("Load YoSpace Source Configuration")
 
@@ -328,6 +329,7 @@ open class BitmovinYospacePlayer(
     // Player Event Listeners
     ///////////////////////////////////////////////////////////////
 
+    @Suppress("DEPRECATION")
     private fun onYospaceEvents() {
         yospaceMetadataSource.addListener {
             BitLog.d("Sending Timed Metadata: $yospaceTime")

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/YospaceAssetType.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/YospaceAssetType.kt
@@ -3,7 +3,10 @@ package com.bitmovin.player.integration.yospace
 enum class YospaceAssetType {
     @Deprecated(
         message = "Use LINEAR_START_OVER for DVR live playback.",
-        replaceWith = ReplaceWith("LINEAR_START_OVER")
+        replaceWith = ReplaceWith(
+            "YospaceAssetType.LINEAR_START_OVER",
+            "com.bitmovin.player.integration.yospace.YospaceAssetType"
+        )
     )
     LINEAR,
     VOD,

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/YospaceAssetType.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/YospaceAssetType.kt
@@ -1,6 +1,10 @@
 package com.bitmovin.player.integration.yospace
 
 enum class YospaceAssetType {
+    @Deprecated(
+        message = "Use LINEAR_START_OVER for DVR live playback.",
+        replaceWith = ReplaceWith("LINEAR_START_OVER")
+    )
     LINEAR,
     VOD,
     LINEAR_START_OVER

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/YospaceErrorCode.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/YospaceErrorCode.kt
@@ -25,9 +25,15 @@ enum class YospaceErrorCode(override val value: Int) : ErrorCode {
 /**
  * 6000 - 6999: Yospace-related error codes
  * - 6004: Unsupported API
+ * - 6005: No Analytics
+ * - 6006: Session initialization issue
+ * - 6007: Session analytics issue
  */
 enum class YospaceWarningCode(override val value: Int) : WarningCode {
-    UnsupportedAPI(6004);
+    UnsupportedAPI(6004),
+    NoAnalytics(6005),
+    SessionInitializationIssue(6006),
+    SessionAnalyticsIssue(6007);
 
     companion object {
         private val map by lazy { YospaceWarningCode.values().associateBy(YospaceWarningCode::value) }

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/YospaceLiveInitializationType.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/YospaceLiveInitializationType.kt
@@ -1,6 +1,6 @@
 package com.bitmovin.player.integration.yospace
 
-enum class YospaceLiveInitialisationType {
+enum class YospaceLiveInitializationType {
     PROXY,
     DIRECT
 }

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/YospacePlayerPolicy.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/YospacePlayerPolicy.kt
@@ -4,8 +4,6 @@ import com.yospace.admanagement.PlaybackPolicyHandler
 import com.yospace.admanagement.Session
 
 class YospacePlayerPolicy(var playerPolicy: BitmovinYospacePlayerPolicy?) : PlaybackPolicyHandler {
-    private var sessionMode: Session.SessionMode? = null
-
     override fun canStop(
         playhead: Long,
         timeline: MutableList<com.yospace.admanagement.AdBreak>?
@@ -52,9 +50,7 @@ class YospacePlayerPolicy(var playerPolicy: BitmovinYospacePlayerPolicy?) : Play
         timeline: MutableList<com.yospace.admanagement.AdBreak>?
     ): Boolean = true
 
-    override fun setSessionMode(mode: Session.SessionMode?) {
-        this.sessionMode = mode
-    }
+    override fun setSessionMode(mode: Session.SessionMode?) = Unit
 
     override fun didSkip(
         from: Long,

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/YospacePlayerPolicy.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/YospacePlayerPolicy.kt
@@ -4,7 +4,7 @@ import com.yospace.admanagement.PlaybackPolicyHandler
 import com.yospace.admanagement.Session
 
 class YospacePlayerPolicy(var playerPolicy: BitmovinYospacePlayerPolicy?) : PlaybackPolicyHandler {
-    private var playbackMode: Session.PlaybackMode? = null
+    private var sessionMode: Session.SessionMode? = null
 
     override fun canStop(
         playhead: Long,
@@ -24,7 +24,8 @@ class YospacePlayerPolicy(var playerPolicy: BitmovinYospacePlayerPolicy?) : Play
 
     override fun willSeekTo(
         position: Long,
-        timeline: MutableList<com.yospace.admanagement.AdBreak>?
+        timeline: MutableList<com.yospace.admanagement.AdBreak>?,
+        duration: Long
     ): Long = playerPolicy?.canSeekTo(position) ?: position
 
     override fun canChangeVolume(
@@ -51,8 +52,8 @@ class YospacePlayerPolicy(var playerPolicy: BitmovinYospacePlayerPolicy?) : Play
         timeline: MutableList<com.yospace.admanagement.AdBreak>?
     ): Boolean = true
 
-    override fun setPlaybackMode(mode: Session.PlaybackMode?) {
-        this.playbackMode = playbackMode
+    override fun setSessionMode(mode: Session.SessionMode?) {
+        this.sessionMode = mode
     }
 
     override fun didSkip(

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/config/YospaceConfig.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/config/YospaceConfig.kt
@@ -1,13 +1,13 @@
 package com.bitmovin.player.integration.yospace.config
 
-import com.bitmovin.player.integration.yospace.YospaceLiveInitialisationType
+import com.bitmovin.player.integration.yospace.YospaceLiveInitializationType
 
 data class YospaceConfig(
     val userAgent: String? = null,
     val readTimeout: Int = 25_000,
     val connectTimeout: Int = 25_000,
     val requestTimeout: Int = 25_000,
-    val liveInitialisationType: YospaceLiveInitialisationType = YospaceLiveInitialisationType.DIRECT,
+    val liveInitializationType: YospaceLiveInitializationType = YospaceLiveInitializationType.DIRECT,
     val isDebug: Boolean = false,
     val filterMetadataType: MetadataType? = MetadataType.EMSG,
     val yospaceDebugMode: YospaceDebugMode = YospaceDebugMode.NONE

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/config/YospaceConfig.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/config/YospaceConfig.kt
@@ -4,8 +4,6 @@ import com.bitmovin.player.integration.yospace.YospaceLiveInitializationType
 
 data class YospaceConfig(
     val userAgent: String? = null,
-    val readTimeout: Int = 25_000,
-    val connectTimeout: Int = 25_000,
     val requestTimeout: Int = 25_000,
     val liveInitializationType: YospaceLiveInitializationType = YospaceLiveInitializationType.DIRECT,
     val isDebug: Boolean = false,

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/config/YospaceConfig.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/config/YospaceConfig.kt
@@ -9,7 +9,8 @@ data class YospaceConfig(
     val requestTimeout: Int = 25_000,
     val liveInitialisationType: YospaceLiveInitialisationType = YospaceLiveInitialisationType.DIRECT,
     val isDebug: Boolean = false,
-    val filterMetadataType: MetadataType? = MetadataType.EMSG
+    val filterMetadataType: MetadataType? = MetadataType.EMSG,
+    val yospaceDebugMode: YospaceDebugMode = YospaceDebugMode.NONE
 )
 
 public enum class MetadataType{

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/config/YospaceDebugMode.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/config/YospaceDebugMode.kt
@@ -1,0 +1,7 @@
+package com.bitmovin.player.integration.yospace.config
+
+enum class YospaceDebugMode {
+    NONE,
+    VALIDATION,
+    ALL
+}

--- a/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
+++ b/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
@@ -14,6 +14,7 @@ import com.bitmovin.player.api.source.SourceType
 import com.bitmovin.player.integration.yospace.BitLog
 import com.bitmovin.player.integration.yospace.BitmovinYospacePlayer
 import com.bitmovin.player.integration.yospace.YospaceAssetType
+import com.bitmovin.player.integration.yospace.YospaceLiveInitialisationType
 import com.bitmovin.player.integration.yospace.config.YospaceConfig
 import com.bitmovin.player.integration.yospace.config.YospaceDebugMode
 import com.bitmovin.player.integration.yospace.config.YospaceSourceConfig
@@ -24,6 +25,7 @@ class MainActivity : AppCompatActivity() {
     private companion object {
         private const val ENABLE_INTEGRATION_LOGS = false
         private const val ENABLE_YOSPACE_VALIDATION_LOGS = true
+        private val LIVE_INITIALISATION_TYPE = YospaceLiveInitialisationType.PROXY
     }
 
     private lateinit var player: BitmovinYospacePlayer
@@ -32,7 +34,7 @@ class MainActivity : AppCompatActivity() {
     private val streams by lazy {
         listOf(
             Stream(
-                "Yospace Live",
+                "Yospace Live (${LIVE_INITIALISATION_TYPE.name})",
                 "https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,hls-ts-pre.m3u8?yo.br=false&yo.av=4&yo.lp=true&yo.pdt=true&yo.lpa=dur",
                 yospaceSourceConfig = YospaceSourceConfig(YospaceAssetType.LINEAR_START_OVER)
             ),
@@ -84,6 +86,7 @@ class MainActivity : AppCompatActivity() {
             this,
             playerConfig,
             yospaceConfig = YospaceConfig(
+                liveInitialisationType = LIVE_INITIALISATION_TYPE,
                 isDebug = ENABLE_INTEGRATION_LOGS,
                 yospaceDebugMode = if (ENABLE_YOSPACE_VALIDATION_LOGS) {
                     YospaceDebugMode.VALIDATION

--- a/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
+++ b/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
@@ -28,7 +28,7 @@ class MainActivity : AppCompatActivity() {
             Stream(
                 "Yospace Live",
                 "https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,hls-ts-pre.m3u8?yo.br=false&yo.av=4&yo.lp=true&yo.pdt=true&yo.lpa=dur",
-                yospaceSourceConfig = YospaceSourceConfig(YospaceAssetType.LINEAR)
+                yospaceSourceConfig = YospaceSourceConfig(YospaceAssetType.LINEAR_START_OVER)
             ),
             Stream(
                 "Yospace VOD",

--- a/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
+++ b/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
@@ -27,18 +27,12 @@ class MainActivity : AppCompatActivity() {
         listOf(
             Stream(
                 "Yospace Live",
-                "https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yospace02,hlssample42.m3u8?yo.br=true&yo.av=4",
+                "https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,hls-ts-pre.m3u8?yo.br=false&yo.av=4&yo.lp=true&yo.pdt=true&yo.lpa=dur",
                 yospaceSourceConfig = YospaceSourceConfig(YospaceAssetType.LINEAR)
             ),
             Stream(
-                "Yospace Companion Ads",
-                "https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yospace02,hlssample42.m3u8?yo.br=true&yo.lp=true&yo.av=4",
-                "https://widevine-stage.license.istreamplanet.com/widevine/api/license/de4c1d30-ac22-4669-8824-19ba9a1dc128",
-                YospaceSourceConfig(YospaceAssetType.LINEAR)
-            ),
-            Stream(
                 "Yospace VOD",
-                "https://csm-e-sdk-validation.bln1.yospace.com/csm/access/207411697/c2FtcGxlL21hc3Rlci5tM3U4?yo.av=3",
+                "https://csm-e-sdk-validation.bln1.yospace.com/csm/access/156611618/c2FtcGxlL21hc3Rlci5tM3U4?yo.av=3",
                 yospaceSourceConfig = YospaceSourceConfig(YospaceAssetType.VOD)
             )
         )

--- a/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
+++ b/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
@@ -54,9 +54,6 @@ class MainActivity : AppCompatActivity() {
         setupSpinner()
         setupPlayer()
         addUIListeners()
-
-        // Auto-load the default stream (live) on launch to ease testing.
-        loadStream(streams[binding.streamSpinner.selectedItemPosition])
     }
 
     override fun onResume() {

--- a/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
+++ b/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
@@ -14,7 +14,7 @@ import com.bitmovin.player.api.source.SourceType
 import com.bitmovin.player.integration.yospace.BitLog
 import com.bitmovin.player.integration.yospace.BitmovinYospacePlayer
 import com.bitmovin.player.integration.yospace.YospaceAssetType
-import com.bitmovin.player.integration.yospace.YospaceLiveInitialisationType
+import com.bitmovin.player.integration.yospace.YospaceLiveInitializationType
 import com.bitmovin.player.integration.yospace.config.YospaceConfig
 import com.bitmovin.player.integration.yospace.config.YospaceDebugMode
 import com.bitmovin.player.integration.yospace.config.YospaceSourceConfig
@@ -25,7 +25,7 @@ class MainActivity : AppCompatActivity() {
     private companion object {
         private const val ENABLE_INTEGRATION_LOGS = true
         private const val ENABLE_YOSPACE_VALIDATION_LOGS = true
-        private val LIVE_INITIALISATION_TYPE = YospaceLiveInitialisationType.PROXY
+        private val LIVE_INITIALIZATION_TYPE = YospaceLiveInitializationType.PROXY
     }
 
     private lateinit var player: BitmovinYospacePlayer
@@ -34,7 +34,7 @@ class MainActivity : AppCompatActivity() {
     private val streams by lazy {
         listOf(
             Stream(
-                "Yospace Live (${LIVE_INITIALISATION_TYPE.name})",
+                "Yospace Live (${LIVE_INITIALIZATION_TYPE.name})",
                 "https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,hls-ts-pre.m3u8?yo.br=false&yo.av=4&yo.lp=true&yo.pdt=true&yo.lpa=dur",
                 yospaceSourceConfig = YospaceSourceConfig(YospaceAssetType.LINEAR_START_OVER)
             ),
@@ -83,7 +83,7 @@ class MainActivity : AppCompatActivity() {
             this,
             playerConfig,
             yospaceConfig = YospaceConfig(
-                liveInitialisationType = LIVE_INITIALISATION_TYPE,
+                liveInitializationType = LIVE_INITIALIZATION_TYPE,
                 isDebug = ENABLE_INTEGRATION_LOGS,
                 yospaceDebugMode = if (ENABLE_YOSPACE_VALIDATION_LOGS) {
                     YospaceDebugMode.VALIDATION

--- a/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
+++ b/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
@@ -15,10 +15,16 @@ import com.bitmovin.player.integration.yospace.BitLog
 import com.bitmovin.player.integration.yospace.BitmovinYospacePlayer
 import com.bitmovin.player.integration.yospace.YospaceAssetType
 import com.bitmovin.player.integration.yospace.config.YospaceConfig
+import com.bitmovin.player.integration.yospace.config.YospaceDebugMode
 import com.bitmovin.player.integration.yospace.config.YospaceSourceConfig
 import com.bitmovin.player.integration.yospacesample.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
+
+    private companion object {
+        private const val ENABLE_INTEGRATION_LOGS = false
+        private const val ENABLE_YOSPACE_VALIDATION_LOGS = true
+    }
 
     private lateinit var player: BitmovinYospacePlayer
     private lateinit var binding: ActivityMainBinding
@@ -46,6 +52,9 @@ class MainActivity : AppCompatActivity() {
         setupSpinner()
         setupPlayer()
         addUIListeners()
+
+        // Auto-load the default stream (live) on launch to ease testing.
+        loadStream(streams[binding.streamSpinner.selectedItemPosition])
     }
 
     override fun onResume() {
@@ -71,7 +80,18 @@ class MainActivity : AppCompatActivity() {
             tweaksConfig = TweaksConfig(useFiletypeExtractorFallbackForHls = true)
         )
 
-        player = BitmovinYospacePlayer(this, playerConfig, yospaceConfig = YospaceConfig())
+        player = BitmovinYospacePlayer(
+            this,
+            playerConfig,
+            yospaceConfig = YospaceConfig(
+                isDebug = ENABLE_INTEGRATION_LOGS,
+                yospaceDebugMode = if (ENABLE_YOSPACE_VALIDATION_LOGS) {
+                    YospaceDebugMode.VALIDATION
+                } else {
+                    YospaceDebugMode.NONE
+                }
+            )
+        )
         player.on<SourceEvent.Load> {
             BitLog.d("Change button")
             binding.loadUnloadButton.text = getString(R.string.unload)

--- a/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
+++ b/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
@@ -23,7 +23,7 @@ import com.bitmovin.player.integration.yospacesample.databinding.ActivityMainBin
 class MainActivity : AppCompatActivity() {
 
     private companion object {
-        private const val ENABLE_INTEGRATION_LOGS = false
+        private const val ENABLE_INTEGRATION_LOGS = true
         private const val ENABLE_YOSPACE_VALIDATION_LOGS = true
         private val LIVE_INITIALISATION_TYPE = YospaceLiveInitialisationType.PROXY
     }


### PR DESCRIPTION
## Summary
- Fix DVR live playhead reporting for LINEAR_START_OVER sessions
- Add public Yospace SDK debug mode config
- Apply live initialisation mode to live/start-over sessions using the factory path for proxy mode

## Validation
- `git diff --check`
- `:yospace:testDebugUnitTest`
- `:yospacesample:assembleDebug`