### PR TITLE
Update README version during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,10 @@ jobs:
       - name: Promote CHANGELOG unreleased section
         run: ./gradlew patchChangelog
 
+      - name: Update version in README
+        run: |
+          sed -i -E "s|(implementation 'com\.bitmovin\.player\.integration:yospace:)[^']+'|\1${{ steps.version.outputs.next }}'|" README.md
+
       - name: Extract release notes
         run: ./gradlew getChangelog -q --console=plain --no-header --no-summary --no-empty-sections --project-version=${{ steps.version.outputs.next }} --output-file=build/release-notes.md
 
@@ -57,7 +61,7 @@ jobs:
         run: |
           git config user.name 'Automated Release'
           git config user.email 'release-automation@bitmovin.com'
-          git add gradle.properties CHANGELOG.md
+          git add gradle.properties CHANGELOG.md README.md
           git commit -m "Release ${{ steps.version.outputs.next }}"
           git tag -a "${{ steps.version.outputs.next }}" -m "${{ steps.version.outputs.next }}"
           git push origin main


### PR DESCRIPTION
## What

Add a step to the release workflow that rewrites the dependency snippet in `README.md` to the release version, and include `README.md` in the release commit.

## Why

The release workflow bumps the version in `gradle.properties` and promotes the `CHANGELOG`, but the `implementation 'com.bitmovin.player.integration:yospace:X.Y.Z'` line in the README stayed pinned to the previous release. So the documented version drifted one release behind on every release.

## How

- New **Update version in README** step (after `patchChangelog`, before extracting release notes) runs `sed` to replace the version in the dependency coordinate with `steps.version.outputs.next`.
- `README.md` added to the `git add` list in the commit step so it lands in the `Release <version>` commit.

## Notes for reviewers

- The regex anchors on the full `com.bitmovin.player.integration:yospace:` coordinate and matches any existing version (`[^']+`), so it is robust to whatever version the README currently holds.
- Runs on `ubuntu-latest` (GNU sed), where `sed -i -E` with the `\1` backreference behaves as written. Verified the substitution against the current README.