### PR TITLE
Add DASH support to Yospace integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- DASH stream support for Yospace assets.
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ val player = BitmovinYospacePlayer(
 // Attach it to your PlayerView (e.g. from your layout)
 playerView.player = player
 
-// Create a SourceConfig pointing at your HLS asset
-val sourceConfig = SourceConfig("asset-url", SourceType.Hls)
+// Create a SourceConfig pointing at your HLS or DASH asset
+val sourceConfig = SourceConfig("asset-url", SourceType.Hls) // or SourceType.Dash
 
 // Create a YospaceSourceConfig with the YospaceAssetType
 val yospaceSourceConfig = YospaceSourceConfig(YospaceAssetType.VOD)

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -489,7 +489,9 @@ open class BitmovinYospacePlayer(
         player.on<PlayerEvent.TimeChanged> {
             val currentTime = getCurrentTimeMinusAd()
 
-            yospaceSession?.onPlayheadUpdate(yospacePlayheadMs())
+            if (yospaceSessionStatus == SessionStatus.INITIALIZED) {
+                yospaceSession?.onPlayheadUpdate(yospacePlayheadMs())
+            }
 
             if (yospaceSession as? SessionLive != null || yospaceSession as? SessionDVRLive != null) {
                 // Live session

--- a/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
+++ b/yospace/src/main/java/com/bitmovin/player/integration/yospace/BitmovinYospacePlayer.kt
@@ -68,6 +68,8 @@ private const val UNSUPPORTED_API = 6004
 private enum class LoadState { LOADING, UNLOADING, UNKNOWN }
 private enum class SessionStatus { NOT_INITIALIZED, INITIALIZED }
 
+private fun MediaSourceType.isSupportedYospaceSource() = this == MediaSourceType.Hls || this == MediaSourceType.Dash
+
 open class BitmovinYospacePlayer(
     private val context: Context,
     private val playerConfig: PlayerConfig = PlayerConfig(),
@@ -176,11 +178,12 @@ open class BitmovinYospacePlayer(
         resetYospaceSession()
 
         val originalUrl = sourceConfig.url
-        if (originalUrl.isEmpty() || sourceConfig.type != MediaSourceType.Hls) {
+        val mediaSourceType = sourceConfig.type
+        if (originalUrl.isEmpty() || !mediaSourceType.isSupportedYospaceSource()) {
             yospaceEventEmitter.emit(
                 YospacePlayerEvent.Error(
                     YospaceErrorCode.InvalidYospaceSource,
-                    "Invalid YoSpace source. You must provide an HLS source"
+                    "Invalid YoSpace source. You must provide an HLS or DASH source"
                 )
             )
             unload()
@@ -196,13 +199,13 @@ open class BitmovinYospacePlayer(
         yospaceSessionProperties = sessionProperties
 
         when (yospaceSourceConfig.assetType) {
-            YospaceAssetType.LINEAR -> loadLive(originalUrl, yospaceSessionProperties!!)
-            YospaceAssetType.VOD -> loadVod(originalUrl, yospaceSessionProperties!!)
-            YospaceAssetType.LINEAR_START_OVER -> loadStartOver(originalUrl, yospaceSessionProperties!!)
+            YospaceAssetType.LINEAR -> loadLive(originalUrl, mediaSourceType, yospaceSessionProperties!!)
+            YospaceAssetType.VOD -> loadVod(originalUrl, mediaSourceType, yospaceSessionProperties!!)
+            YospaceAssetType.LINEAR_START_OVER -> loadStartOver(originalUrl, mediaSourceType, yospaceSessionProperties!!)
         }
     }
 
-    private fun loadLive(originalUrl: String, properties: SessionProperties) =
+    private fun loadLive(originalUrl: String, mediaSourceType: MediaSourceType, properties: SessionProperties) =
         when (yospaceConfig.liveInitializationType) {
             YospaceLiveInitializationType.PROXY -> {
                 val playbackUrl = SessionFactory.create(
@@ -211,7 +214,7 @@ open class BitmovinYospacePlayer(
                     properties,
                     sessionListener
                 )
-                startPlayback(MediaSourceType.Hls, playbackUrl)
+                startPlayback(mediaSourceType, playbackUrl)
             }
             YospaceLiveInitializationType.DIRECT -> SessionLive.create(
                 originalUrl,
@@ -220,7 +223,7 @@ open class BitmovinYospacePlayer(
             )
         }
 
-    private fun loadVod(originalUrl: String, properties: SessionProperties) {
+    private fun loadVod(originalUrl: String, mediaSourceType: MediaSourceType, properties: SessionProperties) {
         SessionVOD.create(
             originalUrl, properties
         ) { event: Event<Session> ->
@@ -228,11 +231,11 @@ open class BitmovinYospacePlayer(
                 event.payload,
                 "Yospace analytics session VOD initialized"
             )
-            startPlayback(MediaSourceType.Hls, event.payload.playbackUrl)
+            startPlayback(mediaSourceType, event.payload.playbackUrl)
         }
     }
 
-    private fun loadStartOver(originalUrl: String, properties: SessionProperties) {
+    private fun loadStartOver(originalUrl: String, mediaSourceType: MediaSourceType, properties: SessionProperties) {
         when (yospaceConfig.liveInitializationType) {
             YospaceLiveInitializationType.PROXY -> {
                 val playbackUrl = SessionFactory.create(
@@ -241,7 +244,7 @@ open class BitmovinYospacePlayer(
                     properties,
                     sessionListener
                 )
-                startPlayback(MediaSourceType.Hls, playbackUrl)
+                startPlayback(mediaSourceType, playbackUrl)
             }
             YospaceLiveInitializationType.DIRECT -> {
                 SessionDVRLive.create(
@@ -577,7 +580,9 @@ open class BitmovinYospacePlayer(
                 }
 
                 yospaceSession?.let {
-                    startPlayback(MediaSourceType.Hls, it.playbackUrl)
+                    sourceConfig?.type?.let { sourceType ->
+                        startPlayback(sourceType, it.playbackUrl)
+                    }
                 }
             }
             Session.SessionState.FAILED, Session.SessionState.NO_ANALYTICS -> handleYospaceSessionFailure(

--- a/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
+++ b/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
@@ -69,6 +69,12 @@ class MainActivity : AppCompatActivity() {
                 "Yospace HLS VOD",
                 "https://csm-e-sdk-validation.bln1.yospace.com/csm/access/156611618/c2FtcGxlL21hc3Rlci5tM3U4?yo.av=3",
                 yospaceSourceConfig = YospaceSourceConfig(YospaceAssetType.VOD)
+            ),
+            Stream(
+                "Yospace DASH VOD",
+                "https://csm-e-sdk-validation-eb.bln1.yospace.com/csm/access/671396777/ZGFzaC9tYW5pZmVzdC5tcGQ=?yo.av=4",
+                sourceType = SourceType.Dash,
+                yospaceSourceConfig = YospaceSourceConfig(YospaceAssetType.VOD)
             )
         )
     }

--- a/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
+++ b/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/MainActivity.kt
@@ -55,12 +55,18 @@ class MainActivity : AppCompatActivity() {
     private val streams by lazy {
         listOf(
             Stream(
-                "Yospace Live (${selectedLiveInitializationType.name})",
+                "Yospace HLS Live (${selectedLiveInitializationType.name})",
                 "https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,hls-ts-pre.m3u8?yo.br=false&yo.av=4&yo.lp=true&yo.pdt=true&yo.lpa=dur",
                 yospaceSourceConfig = YospaceSourceConfig(YospaceAssetType.LINEAR_START_OVER)
             ),
             Stream(
-                "Yospace VOD",
+                "Yospace DASH Live (${selectedLiveInitializationType.name})",
+                "https://csm-e-sdk-validation.bln1.yospace.com/csm/extlive/yosdk02,dash-mp4-pre.mpd?yo.br=false&yo.av=4&yo.lp=true&yo.pdt=true&yo.lpa=dur",
+                sourceType = SourceType.Dash,
+                yospaceSourceConfig = YospaceSourceConfig(YospaceAssetType.LINEAR_START_OVER)
+            ),
+            Stream(
+                "Yospace HLS VOD",
                 "https://csm-e-sdk-validation.bln1.yospace.com/csm/access/156611618/c2FtcGxlL21hc3Rlci5tM3U4?yo.av=3",
                 yospaceSourceConfig = YospaceSourceConfig(YospaceAssetType.VOD)
             )
@@ -177,7 +183,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun loadStream(stream: Stream) {
-        val sourceConfig = SourceConfig(stream.contentUrl, SourceType.Hls)
+        val sourceConfig = SourceConfig(stream.contentUrl, stream.sourceType)
         sourceConfig.drmConfig = WidevineConfig(stream.drmUrl)
 
         player.load(sourceConfig, stream.yospaceSourceConfig, stream.truexConfig)

--- a/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/Stream.kt
+++ b/yospacesample/src/main/java/com/bitmovin/player/integration/yospacesample/Stream.kt
@@ -1,11 +1,13 @@
 package com.bitmovin.player.integration.yospacesample
 
+import com.bitmovin.player.api.source.SourceType
 import com.bitmovin.player.integration.yospace.config.TruexConfig
 import com.bitmovin.player.integration.yospace.config.YospaceSourceConfig
 
 data class Stream(
     val title: String,
     val contentUrl: String,
+    val sourceType: SourceType = SourceType.Hls,
     val drmUrl: String? = null,
     val yospaceSourceConfig: YospaceSourceConfig,
     val truexConfig: TruexConfig? = null


### PR DESCRIPTION
## Summary

- accept DASH sources throughout Yospace session initialization and playback
- preserve the original HLS or DASH source type when loading the Yospace playback URL
- add a DVRLive DASH stream to the sample and document DASH usage

## Motivation

The Android integration rejected all non-HLS sources and always handed Yospace playback URLs to Bitmovin Player as HLS, even though both Bitmovin Player and the Yospace SDK support DASH. This prevented Yospace DASH streams from playing.

## Validation

- `JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19 ./gradlew test`
- `git diff --check`
- verified the sample DVRLive DASH endpoint responds with HTTP 200