### PR TITLE
Speed up CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,9 @@ on:
 concurrency:
   # head_ref is the branch name on pull_request events; ref_name is the branch on
   # push. Using head_ref || ref_name keeps both event types in one group per branch,
-  # so a new push cancels in-flight runs from either trigger.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  # so a new push cancels in-flight runs from either trigger. The head repo keeps
+  # same-named branches from different forks out of one another's group.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Matches player-android-samples-private: head.ref is the branch on pull_request
-  # events, ref_name on push, so both share one group per branch. The head repo keeps
-  # same-named branches from different forks out of one another's group.
+  # head.ref is the branch on pull_request events, ref_name on push, so both share
+  # one group per branch. The head repo keeps same-named branches from different
+  # forks out of one another's group.
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref_name }}
   cancel-in-progress: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,19 @@
 name: CI
 
 on:
-  push:
   pull_request:
+    branches:
+      - main
+  push:
     branches:
       - main
   workflow_dispatch:
 
 concurrency:
-  # head_ref is the branch name on pull_request events; ref_name is the branch on
-  # push. Using head_ref || ref_name keeps both event types in one group per branch,
-  # so a new push cancels in-flight runs from either trigger. The head repo keeps
+  # Matches player-android-samples-private: head.ref is the branch on pull_request
+  # events, ref_name on push, so both share one group per branch. The head repo keeps
   # same-named branches from different forks out of one another's group.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # head_ref is the branch name on pull_request events; ref_name is the branch on
+  # push. Using head_ref || ref_name keeps both event types in one group per branch,
+  # so a new push cancels in-flight runs from either trigger.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,6 @@ jobs:
       - name: Verify CHANGELOG format
         run: ./gradlew getChangelog -q --console=plain --unreleased
 
-      - name: Android Lint
-        run: ./gradlew lint
-
+      # `build` already depends on `lint`, so a separate lint step just re-runs it.
       - name: Build
         run: ./gradlew build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         run: ./gradlew artifactoryPublish
 
       # Promote the release from the internal staging repo to the public, anonymously
-      # readable repo. Mirrors the copy step used by player-android and the analytics SDK.
+      # readable repo.
       - name: Promote artifact to public-releases
         run: |
           VERSION="${{ steps.version.outputs.next }}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,6 @@ org.gradle.jvmargs=-Xmx1536m
 # Library coordinates. Bumped automatically by the release workflow (bumpVersion task).
 libraryVersion=2.3.0
 libraryCode=63
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+# Build both modules in parallel and reuse task outputs across builds.
+org.gradle.parallel=true
+org.gradle.caching=true


### PR DESCRIPTION
Cuts CI wall-clock from ~4m45s to ~1m33s (-67%), measured on a real run of this branch.

### Drop the redundant Android Lint step
`./gradlew build` already depends on `lint`. The separate step cost ~85s, and every lint task then reported `UP-TO-DATE` in the Build step that followed:

```
:yospace:lintAnalyzeDebug UP-TO-DATE
:yospace:lintReportDebug UP-TO-DATE
```

Lint still runs — verified in the Build step's task log.

### Enable the Gradle build cache and parallel execution
Runs reported `Build cache is disabled`, and `org.gradle.parallel` was commented out despite the build having two modules. After a local `clean`, 44 tasks now restore `FROM-CACHE`.

The release workflow picks both up automatically via `gradle.properties`, no workflow change needed.

### Run CI once per change, and cancel superseded runs
`event_name` in the concurrency group put `push` and `pull_request` events in separate groups, so a new push could not cancel an in-flight run. Dropping it alone was not sufficient, as Copilot correctly caught: `github.ref` itself differs per event (`refs/heads/<branch>` vs `refs/pull/<n>/merge`).

Fixing only the group exposed a second problem. With a bare `push:` trigger, every branch commit ran twice, and once cancellation worked the cancelled `push` run reported `lint_and_build` as failed — turning the required check red even though the `pull_request` run passed.

Both are now handled the way our other Android repos already do it — they scope `push` to `main` (or to tags/paths); this repo was the only bare `push:`:

```yaml
on:
  pull_request:
    branches: [main]
  push:
    branches: [main]

concurrency:
  group: ci-${{ github.workflow }}-${{ ... head.repo.full_name || github.repository }}-${{ ... head.ref || github.ref_name }}
  cancel-in-progress: true
```

The head-repo segment keeps same-named branches from different forks out of one another's group (also Copilot's catch). Result: one run per change, superseded runs cancel, and the check rollup is `SUCCESS`.

Note: a branch with no open PR no longer gets CI. Opening the PR (draft is fine) starts checks — the same tradeoff every sibling repo already accepts.

### Measured

| Step | Before | After |
|---|---|---|
| **Total** | **4m 44s** | **1m 33s** |
| Verify CHANGELOG | 39s | 10s |
| Android Lint | 89s | — (removed) |
| Build | 2m 2s | 70s |

All 145 unit tests still run and pass. `Verify CHANGELOG` drops mostly because the warm cache removes dependency re-download, not because of a change to that step.

### Deliberately not changed

- **The release workflow's `Build` step.** Looks redundant next to `artifactoryPublish`, but isn't: publishing does not depend on `assemble`, it uploads a hardcoded `$buildDir/outputs/aar/...` path. That step is what produces the AAR; removing it would publish a stale artifact or fail.
- **`org.gradle.configuration-cache`.** The custom `doLast` release tasks (`decideReleaseVersion`, `bumpVersion`) are the pattern it tends to reject. Worth a separate attempt.
- **`android.enableJetifier=true`.** Likely obsolete on AndroidX-only dependencies and worth ~10-20s, but needs its own verifying build.


